### PR TITLE
库页名称自然排序与卡片封面 letterbox

### DIFF
--- a/app/lib/ui/core/widgets/element/card/catalog_cover_card_shell.dart
+++ b/app/lib/ui/core/widgets/element/card/catalog_cover_card_shell.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hentai_library/ui/core/theme/theme.dart';
 
-/// Shared chrome + 2:3 edge-to-edge cover for catalog grid cards.
+/// Shared chrome + 2:3 cover slot for catalog grid cards.
 ///
 /// Used internally by [ComicCard] / [SeriesCard]; pages should keep using
 /// those domain cards rather than this shell directly.

--- a/app/lib/ui/core/widgets/element/image/card_letterboxed_cover_image.dart
+++ b/app/lib/ui/core/widgets/element/image/card_letterboxed_cover_image.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:hentai_library/core/image/image_decode_cache_size.dart';
+import 'package:hentai_library/ui/core/dto/comic_cover_image.dart';
+import 'package:hentai_library/ui/core/widgets/element/image/app_comic_image.dart';
+import 'package:hentai_library/ui/core/widgets/element/image/comic_cover_placeholder.dart';
+
+/// Catalog-card cover: white letterbox + [BoxFit.contain].
+///
+/// Decode uses [cacheWidth] only so intrinsic aspect is preserved.
+class CardLetterboxedCoverImage extends StatelessWidget {
+  const CardLetterboxedCoverImage({
+    super.key,
+    required this.cover,
+    this.onDecodeError,
+  });
+
+  final ComicCoverImage cover;
+  final VoidCallback? onDecodeError;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final ImageDecodeCacheSize cacheSize = decodeCacheSizeForContext(
+          context,
+          logicalWidth: constraints.maxWidth,
+          logicalHeight: constraints.maxHeight,
+        );
+        return ColoredBox(
+          color: Colors.white,
+          child: AppComicImage(
+            filePath: cover.filePath,
+            memoryBytes: cover.memoryBytes,
+            fit: BoxFit.contain,
+            cacheWidth: cacheSize.cacheWidth,
+            placeholder: const ComicCoverPlaceholder(
+              variant: ComicCoverPlaceholderVariant.card,
+              kind: ComicCoverPlaceholderKind.loading,
+            ),
+            errorPlaceholder: const ComicCoverPlaceholder(
+              variant: ComicCoverPlaceholderVariant.card,
+              kind: ComicCoverPlaceholderKind.error,
+            ),
+            onDecodeError: onDecodeError,
+          ),
+        );
+      },
+    );
+  }
+}

--- a/app/lib/ui/core/widgets/element/image/comic_cover_content.dart
+++ b/app/lib/ui/core/widgets/element/image/comic_cover_content.dart
@@ -38,12 +38,12 @@ class ComicCoverContent extends ConsumerWidget {
         },
       ),
       ComicCoverLoading(:final previous) when previous != null =>
-          CardLetterboxedCoverImage(
-            cover: previous,
-            onDecodeError: () {
-              ref.read(comicCoverProvider(comicId).notifier).markDecodeError();
-            },
-          ),
+        CardLetterboxedCoverImage(
+          cover: previous,
+          onDecodeError: () {
+            ref.read(comicCoverProvider(comicId).notifier).markDecodeError();
+          },
+        ),
       ComicCoverLoading() => const ComicCoverPlaceholder(
         variant: ComicCoverPlaceholderVariant.card,
         kind: ComicCoverPlaceholderKind.loading,

--- a/app/lib/ui/core/widgets/element/image/comic_cover_content.dart
+++ b/app/lib/ui/core/widgets/element/image/comic_cover_content.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:hentai_library/core/image/image_decode_cache_size.dart';
 import 'package:hentai_library/domain/models/enums.dart';
-import 'package:hentai_library/ui/core/dto/comic_cover_image.dart';
 import 'package:hentai_library/ui/core/dto/comic_cover_state.dart';
-import 'package:hentai_library/ui/core/widgets/element/image/app_comic_image.dart';
+import 'package:hentai_library/ui/core/widgets/element/image/card_letterboxed_cover_image.dart';
 import 'package:hentai_library/ui/core/widgets/element/image/comic_cover_placeholder.dart';
 import 'package:hentai_library/ui/features/library/view_models/library_catalog_cover_viewport_notifier.dart';
 import 'package:hentai_library/ui/providers/comic_cover_providers.dart';
@@ -33,18 +31,19 @@ class ComicCoverContent extends ConsumerWidget {
     final ComicCoverState state = ref.watch(comicCoverProvider(comicId));
 
     return switch (state) {
-      ComicCoverReady(:final data) => _buildImage(
-        ref,
-        context,
-        data,
-        ComicCoverPlaceholderKind.loading,
+      ComicCoverReady(:final data) => CardLetterboxedCoverImage(
+        cover: data,
+        onDecodeError: () {
+          ref.read(comicCoverProvider(comicId).notifier).markDecodeError();
+        },
       ),
-      ComicCoverLoading(:final previous) when previous != null => _buildImage(
-        ref,
-        context,
-        previous,
-        ComicCoverPlaceholderKind.loading,
-      ),
+      ComicCoverLoading(:final previous) when previous != null =>
+          CardLetterboxedCoverImage(
+            cover: previous,
+            onDecodeError: () {
+              ref.read(comicCoverProvider(comicId).notifier).markDecodeError();
+            },
+          ),
       ComicCoverLoading() => const ComicCoverPlaceholder(
         variant: ComicCoverPlaceholderVariant.card,
         kind: ComicCoverPlaceholderKind.loading,
@@ -74,40 +73,5 @@ class ComicCoverContent extends ConsumerWidget {
     return visibleIndices.contains(index)
         ? ThumbnailPriority.high
         : ThumbnailPriority.low;
-  }
-
-  Widget _buildImage(
-    WidgetRef ref,
-    BuildContext context,
-    ComicCoverImage data,
-    ComicCoverPlaceholderKind decodeFallbackKind,
-  ) {
-    return LayoutBuilder(
-      builder: (BuildContext context, BoxConstraints constraints) {
-        final ImageDecodeCacheSize cacheSize = decodeCacheSizeForContext(
-          context,
-          logicalWidth: constraints.maxWidth,
-          logicalHeight: constraints.maxHeight,
-        );
-        return AppComicImage(
-          filePath: data.filePath,
-          memoryBytes: data.memoryBytes,
-          fit: BoxFit.cover,
-          cacheWidth: cacheSize.cacheWidth,
-          cacheHeight: cacheSize.cacheHeight,
-          placeholder: ComicCoverPlaceholder(
-            variant: ComicCoverPlaceholderVariant.card,
-            kind: decodeFallbackKind,
-          ),
-          errorPlaceholder: ComicCoverPlaceholder(
-            variant: ComicCoverPlaceholderVariant.card,
-            kind: ComicCoverPlaceholderKind.error,
-          ),
-          onDecodeError: () {
-            ref.read(comicCoverProvider(comicId).notifier).markDecodeError();
-          },
-        );
-      },
-    );
   }
 }

--- a/app/lib/ui/core/widgets/element/image/series_cover_content.dart
+++ b/app/lib/ui/core/widgets/element/image/series_cover_content.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:hentai_library/core/image/image_decode_cache_size.dart';
 import 'package:hentai_library/domain/models/enums.dart';
 import 'package:hentai_library/domain/thumbnail/series_cover_source.dart';
-import 'package:hentai_library/ui/core/widgets/element/image/app_comic_image.dart';
+import 'package:hentai_library/ui/core/dto/comic_cover_image.dart';
+import 'package:hentai_library/ui/core/widgets/element/image/card_letterboxed_cover_image.dart';
 import 'package:hentai_library/ui/core/widgets/element/image/comic_cover_content.dart';
 import 'package:hentai_library/ui/core/widgets/element/image/comic_cover_placeholder.dart';
 import 'package:hentai_library/ui/providers/series_cover_providers.dart';
@@ -36,29 +36,8 @@ class SeriesCoverContent extends ConsumerWidget {
         kind: ComicCoverPlaceholderKind.error,
       ),
       data: (SeriesCoverSource source) => switch (source) {
-        SeriesCoverCustomThumbnail(:final thumbnail) => LayoutBuilder(
-          builder: (BuildContext context, BoxConstraints constraints) {
-            final ImageDecodeCacheSize cacheSize = decodeCacheSizeForContext(
-              context,
-              logicalWidth: constraints.maxWidth,
-              logicalHeight: constraints.maxHeight,
-            );
-            return AppComicImage(
-              memoryBytes: thumbnail,
-              fit: BoxFit.cover,
-              cacheWidth: cacheSize.cacheWidth,
-              cacheHeight: cacheSize.cacheHeight,
-              placeholder: const ComicCoverPlaceholder(
-                variant: ComicCoverPlaceholderVariant.card,
-                kind: ComicCoverPlaceholderKind.loading,
-              ),
-              errorPlaceholder: const ComicCoverPlaceholder(
-                variant: ComicCoverPlaceholderVariant.card,
-                kind: ComicCoverPlaceholderKind.error,
-              ),
-            );
-          },
-        ),
+        SeriesCoverCustomThumbnail(:final thumbnail) =>
+          CardLetterboxedCoverImage(cover: ComicCoverImage.bytes(thumbnail)),
         SeriesCoverFallbackComic(:final comicId) => ComicCoverContent(
           comicId: comicId,
           priority: priority,

--- a/app/test/ui/core/widgets/element/image/card_letterboxed_cover_image_test.dart
+++ b/app/test/ui/core/widgets/element/image/card_letterboxed_cover_image_test.dart
@@ -1,0 +1,40 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hentai_library/ui/core/dto/comic_cover_image.dart';
+import 'package:hentai_library/ui/core/widgets/element/image/app_comic_image.dart';
+import 'package:hentai_library/ui/core/widgets/element/image/card_letterboxed_cover_image.dart';
+
+void main() {
+  testWidgets('ready cover uses contain fit on white letterbox', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 120,
+            height: 180,
+            child: CardLetterboxedCoverImage(
+              cover: ComicCoverImage.bytes(Uint8List.fromList(<int>[1, 2, 3])),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final AppComicImage image = tester.widget(find.byType(AppComicImage));
+    expect(image.fit, BoxFit.contain);
+    // One-dimension decode keeps intrinsic aspect (exact + both dims stretches).
+    expect(image.cacheWidth, isNotNull);
+    expect(image.cacheHeight, isNull);
+
+    expect(
+      find.byWidgetPredicate(
+        (Widget widget) => widget is ColoredBox && widget.color == Colors.white,
+      ),
+      findsOneWidget,
+    );
+  });
+}

--- a/app/test/ui/core/widgets/element/image/comic_cover_content_test.dart
+++ b/app/test/ui/core/widgets/element/image/comic_cover_content_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hentai_library/domain/models/enums.dart';
+import 'package:hentai_library/ui/core/dto/comic_cover_state.dart';
+import 'package:hentai_library/ui/core/theme/theme.dart';
+import 'package:hentai_library/ui/core/widgets/element/image/card_letterboxed_cover_image.dart';
+import 'package:hentai_library/ui/core/widgets/element/image/comic_cover_content.dart';
+import 'package:hentai_library/ui/core/widgets/element/image/comic_cover_placeholder.dart';
+import 'package:hentai_library/ui/providers/comic_cover_providers.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod/misc.dart' show Override;
+
+void main() {
+  testWidgets('no cover shows card placeholder without letterbox', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          comicCoverProvider('comic-1').overrideWith(_NoCoverComicCover.new),
+        ],
+        child: MaterialApp(
+          theme: buildAppTheme(Brightness.light),
+          home: const Scaffold(
+            body: SizedBox(
+              width: 120,
+              height: 180,
+              child: ComicCoverContent(comicId: 'comic-1'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(CardLetterboxedCoverImage), findsNothing);
+    expect(
+      find.byWidgetPredicate(
+        (Widget widget) =>
+            widget is ComicCoverPlaceholder &&
+            widget.variant == ComicCoverPlaceholderVariant.card &&
+            widget.kind == ComicCoverPlaceholderKind.noCover,
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.byWidgetPredicate(
+        (Widget widget) => widget is ColoredBox && widget.color == Colors.white,
+      ),
+      findsNothing,
+    );
+  });
+}
+
+class _NoCoverComicCover extends ComicCover {
+  @override
+  ComicCoverState build(String comicId) => const ComicCoverNoCover();
+
+  @override
+  void ensureLoaded({ThumbnailPriority priority = ThumbnailPriority.high}) {}
+}

--- a/app/test/ui/core/widgets/element/image/series_cover_content_test.dart
+++ b/app/test/ui/core/widgets/element/image/series_cover_content_test.dart
@@ -20,9 +20,9 @@ void main() {
     await tester.pumpWidget(
       ProviderScope(
         overrides: <Override>[
-          seriesCoverSourceProvider('series-1').overrideWith(
-            (Ref ref) async => SeriesCoverCustomThumbnail(bytes),
-          ),
+          seriesCoverSourceProvider(
+            'series-1',
+          ).overrideWith((Ref ref) async => SeriesCoverCustomThumbnail(bytes)),
         ],
         child: MaterialApp(
           theme: buildAppTheme(Brightness.light),

--- a/app/test/ui/core/widgets/element/image/series_cover_content_test.dart
+++ b/app/test/ui/core/widgets/element/image/series_cover_content_test.dart
@@ -1,0 +1,54 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hentai_library/domain/thumbnail/series_cover_source.dart';
+import 'package:hentai_library/ui/core/theme/theme.dart';
+import 'package:hentai_library/ui/core/widgets/element/image/app_comic_image.dart';
+import 'package:hentai_library/ui/core/widgets/element/image/card_letterboxed_cover_image.dart';
+import 'package:hentai_library/ui/core/widgets/element/image/series_cover_content.dart';
+import 'package:hentai_library/ui/providers/series_cover_providers.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod/misc.dart' show Override;
+
+void main() {
+  testWidgets('custom series thumbnail uses contain fit on white letterbox', (
+    WidgetTester tester,
+  ) async {
+    final Uint8List bytes = Uint8List.fromList(<int>[1, 2, 3]);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          seriesCoverSourceProvider('series-1').overrideWith(
+            (Ref ref) async => SeriesCoverCustomThumbnail(bytes),
+          ),
+        ],
+        child: MaterialApp(
+          theme: buildAppTheme(Brightness.light),
+          home: const Scaffold(
+            body: SizedBox(
+              width: 120,
+              height: 180,
+              child: SeriesCoverContent(seriesId: 'series-1'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(CardLetterboxedCoverImage), findsOneWidget);
+
+    final AppComicImage image = tester.widget(find.byType(AppComicImage));
+    expect(image.fit, BoxFit.contain);
+    expect(image.memoryBytes, bytes);
+
+    expect(
+      find.byWidgetPredicate(
+        (Widget widget) => widget is ColoredBox && widget.color == Colors.white,
+      ),
+      findsOneWidget,
+    );
+  });
+}

--- a/core/crates/core/src/comic/page_query.rs
+++ b/core/crates/core/src/comic/page_query.rs
@@ -54,16 +54,27 @@ fn sort_join_clause(field: ComicSortFieldDto) -> &'static str {
 
 fn build_order_by_clause(sort: &ComicSortOptionDto) -> String {
     let direction = if sort.descending { "DESC" } else { "ASC" };
-    let primary = match sort.field {
-        ComicSortFieldDto::Title => format!("lower(m.title) {direction}"),
-        ComicSortFieldDto::CreatedAt => format!("c.created_at {direction}"),
-        ComicSortFieldDto::LastUpdatedAt => format!("c.last_updated_at {direction}"),
-        ComicSortFieldDto::PublishedAt => format!("m.published_at {direction} NULLS LAST"),
-        ComicSortFieldDto::ReadAt => format!("rh.last_read_time {direction} NULLS LAST"),
-        ComicSortFieldDto::FileSize => format!("c.resource_size {direction}"),
-        ComicSortFieldDto::PageCount => format!("m.page_count {direction}"),
-    };
-    format!("{primary}, lower(m.title) ASC")
+    match sort.field {
+        ComicSortFieldDto::Title => {
+            format!("m.title_sort_key {direction}, c.comic_id ASC")
+        }
+        other => {
+            let primary = match other {
+                ComicSortFieldDto::Title => unreachable!(),
+                ComicSortFieldDto::CreatedAt => format!("c.created_at {direction}"),
+                ComicSortFieldDto::LastUpdatedAt => format!("c.last_updated_at {direction}"),
+                ComicSortFieldDto::PublishedAt => {
+                    format!("m.published_at {direction} NULLS LAST")
+                }
+                ComicSortFieldDto::ReadAt => {
+                    format!("rh.last_read_time {direction} NULLS LAST")
+                }
+                ComicSortFieldDto::FileSize => format!("c.resource_size {direction}"),
+                ComicSortFieldDto::PageCount => format!("m.page_count {direction}"),
+            };
+            format!("{primary}, m.title_sort_key ASC, c.comic_id ASC")
+        }
+    }
 }
 
 fn build_where_clause(filter: &ComicFilterDto, values: &mut Vec<Value>) -> String {
@@ -182,7 +193,7 @@ mod tests {
         );
         assert!(sql.sql.contains("LEFT JOIN comic_reading_histories rh"));
         assert!(sql.sql.contains("ORDER BY rh.last_read_time DESC NULLS LAST"));
-        assert!(sql.sql.contains(", lower(m.title) ASC"));
+        assert!(sql.sql.contains(", m.title_sort_key ASC, c.comic_id ASC"));
     }
 
     #[test]
@@ -196,8 +207,26 @@ mod tests {
             10,
             5,
         );
-        assert!(sql.sql.contains("ORDER BY m.page_count ASC, lower(m.title) ASC"));
+        assert!(sql.sql.contains(
+            "ORDER BY m.page_count ASC, m.title_sort_key ASC, c.comic_id ASC"
+        ));
         assert!(!sql.sql.contains("comic_reading_histories"));
+    }
+
+    #[test]
+    fn order_by_title_uses_sort_key() {
+        let sql = build_ids_page_query(
+            &ComicFilterDto::default(),
+            &ComicSortOptionDto {
+                field: ComicSortFieldDto::Title,
+                descending: false,
+            },
+            10,
+            0,
+        );
+        assert!(sql.sql.contains(
+            "ORDER BY m.title_sort_key ASC, c.comic_id ASC"
+        ));
     }
 
     #[test]

--- a/core/crates/core/src/comic/write.rs
+++ b/core/crates/core/src/comic/write.rs
@@ -8,7 +8,7 @@ use crate::error::HentaiError;
 use crate::metadata_lock::comic_auto_locks;
 use crate::sync::series_rebuild::rebuild_series_from_comics;
 use crate::sync::writer::{replace_comic_authors, replace_comic_tags};
-use crate::util::decode_basic_html_entities;
+use crate::util::{decode_basic_html_entities, compute_sort_key};
 
 #[derive(Debug, Clone, Default)]
 pub struct UpdateComicUserMetaDto {
@@ -94,7 +94,9 @@ pub async fn update_comic_user_meta(
             ..Default::default()
         };
         if let Some(title) = meta.title {
-            active.title = Set(decode_basic_html_entities(&title));
+            let decoded = decode_basic_html_entities(&title);
+            active.title_sort_key = Set(compute_sort_key(&decoded));
+            active.title = Set(decoded);
             meta_touched = true;
         }
         if let Some(content_rating) = meta.content_rating {

--- a/core/crates/core/src/entity/comic_meta.rs
+++ b/core/crates/core/src/entity/comic_meta.rs
@@ -6,6 +6,7 @@ pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub comic_id: String,
     pub title: String,
+    pub title_sort_key: String,
     pub content_rating: String,
     pub page_count: i32,
     pub description: Option<String>,

--- a/core/crates/core/src/entity/series.rs
+++ b/core/crates/core/src/entity/series.rs
@@ -8,6 +8,7 @@ pub struct Model {
     #[sea_orm(unique)]
     pub folder_path: String,
     pub name: String,
+    pub name_sort_key: String,
     pub serialization_status: String,
     pub total_count: Option<i32>,
     pub name_locked: bool,

--- a/core/crates/core/src/migration/m20260717_000008_ensure_greenfield_schema.rs
+++ b/core/crates/core/src/migration/m20260717_000008_ensure_greenfield_schema.rs
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS comics (
 CREATE TABLE IF NOT EXISTS comic_meta (
   comic_id TEXT NOT NULL PRIMARY KEY,
   title TEXT NOT NULL,
+  title_sort_key TEXT NOT NULL DEFAULT '',
   content_rating TEXT NOT NULL DEFAULT 'unknown',
   page_count INTEGER NOT NULL CHECK (page_count > 0),
   description TEXT,
@@ -55,6 +56,7 @@ CREATE TABLE IF NOT EXISTS series (
   series_id TEXT NOT NULL PRIMARY KEY,
   folder_path TEXT NOT NULL UNIQUE,
   name TEXT NOT NULL,
+  name_sort_key TEXT NOT NULL DEFAULT '',
   serialization_status TEXT NOT NULL DEFAULT 'unknown'
     CHECK (serialization_status IN ('unknown', 'ongoing', 'ended', 'hiatus')),
   total_count INTEGER NULL CHECK (total_count IS NULL OR total_count > 0)

--- a/core/crates/core/src/migration/m20260805_000013_title_name_sort_keys.rs
+++ b/core/crates/core/src/migration/m20260805_000013_title_name_sort_keys.rs
@@ -1,0 +1,134 @@
+use sea_orm::{ConnectionTrait, Statement};
+use sea_orm_migration::prelude::*;
+
+use crate::util::natural_sort::compute_sort_key;
+
+/// Persist lexicographic sort keys for catalog title/name natural ordering.
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        add_text_column(manager, "comic_meta", "title_sort_key").await?;
+        add_text_column(manager, "series", "name_sort_key").await?;
+        backfill_comic_title_sort_keys(manager).await?;
+        backfill_series_name_sort_keys(manager).await?;
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        Ok(())
+    }
+}
+
+async fn add_text_column(
+    manager: &SchemaManager<'_>,
+    table: &str,
+    column: &str,
+) -> Result<(), DbErr> {
+    if !table_exists(manager, table).await? {
+        return Ok(());
+    }
+    if column_exists(manager, table, column).await? {
+        return Ok(());
+    }
+    manager
+        .get_connection()
+        .execute_unprepared(&format!(
+            "ALTER TABLE {table} ADD COLUMN {column} TEXT NOT NULL DEFAULT ''"
+        ))
+        .await?;
+    Ok(())
+}
+
+async fn backfill_comic_title_sort_keys(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    if !table_exists(manager, "comic_meta").await? {
+        return Ok(());
+    }
+    if !column_exists(manager, "comic_meta", "title_sort_key").await? {
+        return Ok(());
+    }
+    let db = manager.get_connection();
+    let rows = db
+        .query_all(Statement::from_string(
+            manager.get_database_backend(),
+            "SELECT comic_id, title FROM comic_meta".to_string(),
+        ))
+        .await?;
+    for row in rows {
+        let comic_id: String = row.try_get_by_index(0)?;
+        let title: String = row.try_get_by_index(1)?;
+        let key = compute_sort_key(&title);
+        db.execute(Statement::from_sql_and_values(
+            manager.get_database_backend(),
+            "UPDATE comic_meta SET title_sort_key = ? WHERE comic_id = ?",
+            [
+                sea_orm::Value::String(Some(Box::new(key))),
+                sea_orm::Value::String(Some(Box::new(comic_id))),
+            ],
+        ))
+        .await?;
+    }
+    Ok(())
+}
+
+async fn backfill_series_name_sort_keys(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    if !table_exists(manager, "series").await? {
+        return Ok(());
+    }
+    if !column_exists(manager, "series", "name_sort_key").await? {
+        return Ok(());
+    }
+    let db = manager.get_connection();
+    let rows = db
+        .query_all(Statement::from_string(
+            manager.get_database_backend(),
+            "SELECT series_id, name FROM series".to_string(),
+        ))
+        .await?;
+    for row in rows {
+        let series_id: String = row.try_get_by_index(0)?;
+        let name: String = row.try_get_by_index(1)?;
+        let key = compute_sort_key(&name);
+        db.execute(Statement::from_sql_and_values(
+            manager.get_database_backend(),
+            "UPDATE series SET name_sort_key = ? WHERE series_id = ?",
+            [
+                sea_orm::Value::String(Some(Box::new(key))),
+                sea_orm::Value::String(Some(Box::new(series_id))),
+            ],
+        ))
+        .await?;
+    }
+    Ok(())
+}
+
+async fn table_exists(manager: &SchemaManager<'_>, table: &str) -> Result<bool, DbErr> {
+    let stmt = Statement::from_string(
+        manager.get_database_backend(),
+        format!("SELECT 1 FROM sqlite_master WHERE type='table' AND name='{table}' LIMIT 1"),
+    );
+    Ok(manager
+        .get_connection()
+        .query_one(stmt)
+        .await?
+        .is_some())
+}
+
+async fn column_exists(
+    manager: &SchemaManager<'_>,
+    table: &str,
+    column: &str,
+) -> Result<bool, DbErr> {
+    let stmt = Statement::from_string(
+        manager.get_database_backend(),
+        format!("PRAGMA table_info({table})"),
+    );
+    let rows = manager.get_connection().query_all(stmt).await?;
+    Ok(rows.iter().any(|row| {
+        row.try_get_by_index::<String>(1)
+            .map(|name| name == column)
+            .unwrap_or(false)
+    }))
+}

--- a/core/crates/core/src/migration/mod.rs
+++ b/core/crates/core/src/migration/mod.rs
@@ -11,6 +11,7 @@ mod m20260718_000009_user_set_and_series_thumbnails;
 mod m20260801_000010_drop_series_reading_histories;
 mod m20260801_000011_series_item_sort_order_real;
 mod m20260801_000012_metadata_field_locks;
+mod m20260805_000013_title_name_sort_keys;
 
 pub struct Migrator;
 
@@ -29,6 +30,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260801_000010_drop_series_reading_histories::Migration),
             Box::new(m20260801_000011_series_item_sort_order_real::Migration),
             Box::new(m20260801_000012_metadata_field_locks::Migration),
+            Box::new(m20260805_000013_title_name_sort_keys::Migration),
         ]
     }
 }

--- a/core/crates/core/src/series/page_query.rs
+++ b/core/crates/core/src/series/page_query.rs
@@ -42,13 +42,13 @@ fn build_order_by_clause(sort: &SeriesSortOptionDto, _values: &mut Vec<Value>) -
     match sort.field {
         SeriesSortFieldDto::Name => {
             let direction = if sort.descending { "DESC" } else { "ASC" };
-            format!("lower(s.name) {direction}, s.series_id ASC")
+            format!("s.name_sort_key {direction}, s.series_id ASC")
         }
         SeriesSortFieldDto::ComicCount => {
             let direction = if sort.descending { "DESC" } else { "ASC" };
             format!(
                 "(SELECT COUNT(*) FROM series_items si WHERE si.series_id = s.series_id) {direction}, \
-                 lower(s.name) ASC, s.series_id ASC"
+                 s.name_sort_key ASC, s.series_id ASC"
             )
         }
         SeriesSortFieldDto::Random => {

--- a/core/crates/core/src/series/write.rs
+++ b/core/crates/core/src/series/write.rs
@@ -4,6 +4,7 @@ use crate::db::{connection, map_db_err};
 use crate::entity::{prelude::*, series, series_items};
 use crate::error::HentaiError;
 use crate::metadata_lock::series_auto_locks;
+use crate::util::compute_sort_key;
 
 #[derive(Debug, Clone, Default)]
 pub struct UpdateSeriesUserMetaDto {
@@ -50,6 +51,7 @@ pub async fn update_series_user_meta(
         if trimmed.is_empty() {
             return Err(HentaiError::validation("系列名称不能为空".to_string()));
         }
+        active.name_sort_key = Set(compute_sort_key(trimmed));
         active.name = Set(trimmed.to_string());
     }
     if let Some(serialization_status) = meta.serialization_status {

--- a/core/crates/core/src/sync/refresh.rs
+++ b/core/crates/core/src/sync/refresh.rs
@@ -7,6 +7,7 @@ use crate::db::{connection, map_db_err};
 use crate::entity::{prelude::*, series, series_items};
 use crate::error::HentaiError;
 use crate::series_id::series_name_from_folder_path;
+use crate::util::compute_sort_key;
 
 use crate::metadata_lock::{
     merge_kept_scan_with_existing, merge_series_name, series_name_needs_write,
@@ -117,11 +118,13 @@ pub async fn refresh_series_metadata(
     let folder_name = series_name_from_folder_path(&series_row.folder_path);
     if series_name_needs_write(series_row.name_locked, &series_row.name, &folder_name) {
         let mut active: series::ActiveModel = series_row.clone().into();
-        active.name = Set(merge_series_name(
+        let merged_name = merge_series_name(
             series_row.name_locked,
             &series_row.name,
             &folder_name,
-        ));
+        );
+        active.name_sort_key = Set(compute_sort_key(&merged_name));
+        active.name = Set(merged_name);
         active.update(&db).await.map_err(map_db_err)?;
     }
 

--- a/core/crates/core/src/sync/series_rebuild.rs
+++ b/core/crates/core/src/sync/series_rebuild.rs
@@ -11,6 +11,7 @@ use crate::metadata_lock::{merge_series_name, resolve_member_sort_order};
 use crate::series_id::{
     folder_path_from_comic_path, series_id_from_folder_path, series_name_from_folder_path,
 };
+use crate::util::compute_sort_key;
 
 pub async fn rebuild_series_from_comics<C: ConnectionTrait>(
     db: &C,
@@ -55,16 +56,19 @@ pub async fn rebuild_series_from_comics<C: ConnectionTrait>(
             let mut active: series::ActiveModel = existing_row.clone().into();
             active.folder_path = Set(folder_path);
             // serialization_status / total_count have no scan source → never overwritten.
-            active.name = Set(merge_series_name(
+            let merged_name = merge_series_name(
                 existing_row.name_locked,
                 &existing_row.name,
                 &name,
-            ));
+            );
+            active.name_sort_key = Set(compute_sort_key(&merged_name));
+            active.name = Set(merged_name);
             active.update(db).await.map_err(crate::db::map_db_err)?;
         } else {
             Series::insert(series::ActiveModel {
                 series_id: Set(series_id.clone()),
                 folder_path: Set(folder_path),
+                name_sort_key: Set(compute_sort_key(&name)),
                 name: Set(name),
                 serialization_status: Set("unknown".to_string()),
                 total_count: Set(None),

--- a/core/crates/core/src/sync/writer.rs
+++ b/core/crates/core/src/sync/writer.rs
@@ -10,6 +10,7 @@ use crate::entity::{
 };
 use crate::error::HentaiError;
 use crate::history::normalize_reading_history_titles;
+use crate::util::compute_sort_key;
 
 use super::migrate::ComicMigration;
 use super::plan::ComicScanReplacePlan;
@@ -72,6 +73,7 @@ async fn apply_comic_rekey<C: ConnectionTrait>(
     let meta_active = comic_meta::ActiveModel {
         comic_id: Set(to_id.clone()),
         title: Set(comic.title.clone()),
+        title_sort_key: Set(compute_sort_key(&comic.title)),
         content_rating: Set(comic.content_rating.clone()),
         page_count: Set(comic.page_count),
         description: Set(comic.description.clone()),
@@ -299,6 +301,7 @@ pub(crate) async fn upsert_comics<C: ConnectionTrait>(
         let meta_active = comic_meta::ActiveModel {
             comic_id: Set(comic.comic_id.clone()),
             title: Set(comic.title.clone()),
+            title_sort_key: Set(compute_sort_key(&comic.title)),
             content_rating: Set(comic.content_rating.clone()),
             page_count: Set(comic.page_count),
             description: Set(comic.description.clone()),
@@ -315,6 +318,7 @@ pub(crate) async fn upsert_comics<C: ConnectionTrait>(
                 sea_orm::sea_query::OnConflict::column(comic_meta::Column::ComicId)
                     .update_columns([
                         comic_meta::Column::Title,
+                        comic_meta::Column::TitleSortKey,
                         comic_meta::Column::ContentRating,
                         comic_meta::Column::PageCount,
                         comic_meta::Column::Description,

--- a/core/crates/core/src/util/mod.rs
+++ b/core/crates/core/src/util/mod.rs
@@ -2,3 +2,4 @@ pub mod html_entities;
 pub mod natural_sort;
 
 pub use html_entities::decode_basic_html_entities;
+pub use natural_sort::{compare_filename_natural, compute_sort_key};

--- a/core/crates/core/src/util/natural_sort.rs
+++ b/core/crates/core/src/util/natural_sort.rs
@@ -16,6 +16,26 @@ pub fn compare_filename_natural(a: &str, b: &str) -> std::cmp::Ordering {
     a_parts.len().cmp(&b_parts.len())
 }
 
+/// Lexicographic sort key approximating ASCII-case-insensitive natural order.
+///
+/// Numeric runs are zero-padded to [`SORT_KEY_NUMERIC_WIDTH`] digits so that
+/// SQL `ORDER BY sort_key` matches natural numeric ordering (e.g. `Vol 2` < `Vol 10`).
+pub const SORT_KEY_NUMERIC_WIDTH: usize = 20;
+
+pub fn compute_sort_key(display: &str) -> String {
+    let mut out = String::with_capacity(display.len());
+    for part in split_natural(display) {
+        if let Ok(n) = part.parse::<u64>() {
+            out.push_str(&format!("{n:0width$}", width = SORT_KEY_NUMERIC_WIDTH));
+        } else {
+            for ch in part.chars() {
+                out.push(ch.to_ascii_lowercase());
+            }
+        }
+    }
+    out
+}
+
 fn split_natural(s: &str) -> Vec<String> {
     let mut parts = Vec::new();
     let mut current = String::new();
@@ -44,5 +64,32 @@ mod tests {
         let mut names = vec!["page2", "page10", "page1"];
         names.sort_by(|a, b| compare_filename_natural(a, b));
         assert_eq!(names, vec!["page1", "page2", "page10"]);
+    }
+
+    #[test]
+    fn sort_key_orders_vol_numbers_naturally() {
+        let a = compute_sort_key("Vol 2");
+        let b = compute_sort_key("Vol 10");
+        assert!(a < b, "expected {a:?} < {b:?}");
+    }
+
+    #[test]
+    fn sort_key_is_ascii_case_insensitive() {
+        assert_eq!(compute_sort_key("Alpha"), compute_sort_key("alpha"));
+        assert_eq!(compute_sort_key("Beta"), compute_sort_key("BETA"));
+        assert!(compute_sort_key("Alpha") < compute_sort_key("Beta"));
+    }
+
+    #[test]
+    fn sort_key_leading_zeros_share_numeric_value() {
+        assert_eq!(compute_sort_key("01"), compute_sort_key("1"));
+        assert_eq!(compute_sort_key("Vol 01"), compute_sort_key("Vol 1"));
+    }
+
+    #[test]
+    fn sort_key_orders_match_padded_lexicographic_list() {
+        let mut titles = vec!["Vol 10", "Vol 2", "vol 1", "Alpha"];
+        titles.sort_by_key(|t| compute_sort_key(t));
+        assert_eq!(titles, vec!["Alpha", "vol 1", "Vol 2", "Vol 10"]);
     }
 }

--- a/core/crates/core/tests/catalog_title_natural_sort.rs
+++ b/core/crates/core/tests/catalog_title_natural_sort.rs
@@ -1,0 +1,203 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use hentai_core::sync::series_rebuild::rebuild_series_from_comics;
+use hentai_core::util::compute_sort_key;
+use hentai_core::{
+    connection, fetch_comics_page, fetch_series_page, init_db_at_path, update_comic_user_meta,
+    ComicFilterDto, ComicSortFieldDto, ComicSortOptionDto, PageRequestDto, SeriesFilterDto,
+    SeriesSortFieldDto, SeriesSortOptionDto, UpdateComicUserMetaDto,
+};
+use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
+use tempfile::TempDir;
+
+static DB_INIT_LOCK: Mutex<()> = Mutex::new(());
+
+fn with_global_db(test: impl FnOnce()) {
+    let _guard = DB_INIT_LOCK
+        .lock()
+        .expect("global db tests must run serially");
+    test();
+}
+
+fn fixture_sql() -> String {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    fs::read_to_string(manifest_dir.join("../../tests/fixtures/drift_v2.sql"))
+        .expect("read drift_v2.sql")
+}
+
+fn create_fixture_db(dir: &Path) -> PathBuf {
+    let db_path = dir.join("fixture.sqlite");
+    let runtime = tokio::runtime::Runtime::new().expect("runtime");
+    runtime.block_on(async {
+        let conn = Database::connect(format!(
+            "sqlite://{}?mode=rwc",
+            db_path.to_string_lossy().replace('\\', "/")
+        ))
+        .await
+        .expect("connect");
+        for stmt in fixture_sql().split(';') {
+            let sql = stmt.trim();
+            if sql.is_empty() || sql.starts_with("--") {
+                continue;
+            }
+            conn.execute(Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                sql.to_string(),
+            ))
+            .await
+            .expect("execute sql");
+        }
+    });
+    db_path
+}
+
+async fn clear_library(db: &DatabaseConnection) {
+    db.execute(Statement::from_string(
+        sea_orm::DatabaseBackend::Sqlite,
+        "DELETE FROM series_items; DELETE FROM series; DELETE FROM comic_meta; DELETE FROM comics"
+            .to_string(),
+    ))
+    .await
+    .expect("clear");
+}
+
+async fn insert_comic(db: &DatabaseConnection, comic_id: &str, path: &str, title: &str) {
+    db.execute(Statement::from_sql_and_values(
+        sea_orm::DatabaseBackend::Sqlite,
+        "INSERT INTO comics (comic_id, path, resource_type, resource_size, created_at, last_updated_at) \
+         VALUES (?, ?, 'cbz', 1, 1, 1)",
+        [
+            sea_orm::Value::String(Some(Box::new(comic_id.to_string()))),
+            sea_orm::Value::String(Some(Box::new(path.to_string()))),
+        ],
+    ))
+    .await
+    .expect("insert comic");
+    let key = compute_sort_key(title);
+    db.execute(Statement::from_sql_and_values(
+        sea_orm::DatabaseBackend::Sqlite,
+        "INSERT INTO comic_meta (comic_id, title, title_sort_key, content_rating, page_count) \
+         VALUES (?, ?, ?, 'unknown', 1)",
+        [
+            sea_orm::Value::String(Some(Box::new(comic_id.to_string()))),
+            sea_orm::Value::String(Some(Box::new(title.to_string()))),
+            sea_orm::Value::String(Some(Box::new(key))),
+        ],
+    ))
+    .await
+    .expect("insert meta");
+}
+
+#[test]
+fn fetch_comics_page_title_asc_uses_natural_order() {
+    with_global_db(|| {
+        let temp = TempDir::new().expect("tempdir");
+        let db_path = create_fixture_db(temp.path());
+        let runtime = tokio::runtime::Runtime::new().expect("runtime");
+        runtime.block_on(async {
+            init_db_at_path(&db_path).await.expect("init_db");
+            let db = connection().expect("connection");
+            clear_library(&db).await;
+            insert_comic(&db, "c10", "E:/lib/Vol 10.cbz", "Vol 10").await;
+            insert_comic(&db, "c2", "E:/lib/Vol 2.cbz", "Vol 2").await;
+            insert_comic(&db, "c1", "E:/lib/Vol 1.cbz", "vol 1").await;
+
+            let page = fetch_comics_page(
+                PageRequestDto {
+                    page: 1,
+                    page_size: 50,
+                },
+                ComicFilterDto {
+                    show_r18: true,
+                    ..Default::default()
+                },
+                ComicSortOptionDto {
+                    field: ComicSortFieldDto::Title,
+                    descending: false,
+                },
+            )
+            .await
+            .expect("page");
+
+            let titles: Vec<&str> = page.items.iter().map(|c| c.title.as_str()).collect();
+            assert_eq!(titles, vec!["vol 1", "Vol 2", "Vol 10"]);
+        });
+    });
+}
+
+#[test]
+fn fetch_series_page_name_asc_uses_natural_order() {
+    with_global_db(|| {
+        let temp = TempDir::new().expect("tempdir");
+        let db_path = create_fixture_db(temp.path());
+        let runtime = tokio::runtime::Runtime::new().expect("runtime");
+        runtime.block_on(async {
+            init_db_at_path(&db_path).await.expect("init_db");
+            let db = connection().expect("connection");
+            clear_library(&db).await;
+            insert_comic(&db, "c10", "E:/lib/Vol 10/a.cbz", "a").await;
+            insert_comic(&db, "c2", "E:/lib/Vol 2/a.cbz", "a").await;
+            insert_comic(&db, "c1", "E:/lib/Vol 1/a.cbz", "a").await;
+            rebuild_series_from_comics(&db).await.expect("rebuild");
+
+            let page = fetch_series_page(
+                PageRequestDto {
+                    page: 1,
+                    page_size: 50,
+                },
+                SeriesFilterDto {
+                    show_r18: true,
+                    require_items: true,
+                    ..Default::default()
+                },
+                SeriesSortOptionDto {
+                    field: SeriesSortFieldDto::Name,
+                    descending: false,
+                },
+            )
+            .await
+            .expect("page");
+
+            let names: Vec<&str> = page.items.iter().map(|s| s.name.as_str()).collect();
+            assert_eq!(names, vec!["Vol 1", "Vol 2", "Vol 10"]);
+        });
+    });
+}
+
+#[test]
+fn update_comic_title_refreshes_title_sort_key() {
+    with_global_db(|| {
+        let temp = TempDir::new().expect("tempdir");
+        let db_path = create_fixture_db(temp.path());
+        let runtime = tokio::runtime::Runtime::new().expect("runtime");
+        runtime.block_on(async {
+            init_db_at_path(&db_path).await.expect("init_db");
+            let db = connection().expect("connection");
+            clear_library(&db).await;
+            insert_comic(&db, "c1", "E:/lib/a.cbz", "Old").await;
+
+            update_comic_user_meta(
+                "c1",
+                UpdateComicUserMetaDto {
+                    title: Some("Vol 2".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("update");
+
+            let row = db
+                .query_one(Statement::from_string(
+                    sea_orm::DatabaseBackend::Sqlite,
+                    "SELECT title_sort_key FROM comic_meta WHERE comic_id = 'c1'".to_string(),
+                ))
+                .await
+                .expect("query")
+                .expect("row");
+            let key: String = row.try_get_by_index(0).expect("key");
+            assert_eq!(key, compute_sort_key("Vol 2"));
+        });
+    });
+}


### PR DESCRIPTION
## Summary
- 库页标题/名称排序改为自然序：写入 `title_sort_key` / `name_sort_key` 并迁移回填，查询按 sort key 排序
- 目录卡片封面改为 contain + 白底 letterbox，解码仅限宽以保持比例
- 合并上述两个功能分支并补齐相关单测

## Test plan
- [ ] `flutter analyze` / `dart analyze` 通过
- [ ] 库页按名称排序时，含数字标题按自然序排列（如 2 在 10 前）
- [ ] 目录/系列卡片封面不裁切，白边 letterbox 显示正常
- [ ] 相关 widget / Rust 单测通过
