### PR TITLE
加固测试体系：CI 硬门禁、FRB 契约测与共享 harness (#106)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ jobs:
   analyze:
     name: analyze
     runs-on: ubuntu-latest
-    continue-on-error: true
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -50,7 +49,7 @@ jobs:
 
       - name: Verify formatting
         working-directory: app
-        run: dart format --output=none --set-exit-if-changed .
+        run: dart format --output=none --set-exit-if-changed lib test
 
       - name: Analyze
         working-directory: app
@@ -71,10 +70,19 @@ jobs:
 
       - name: Run unit tests
         working-directory: app
-        run: flutter test test/domain test/core test/project_layout_test.dart
+        # Hard gate: domain/core/layout + data (FRB thin edge) + promoted fast UI.
+        # See docs/agents/testing.md dual-track promotion checklist.
+        run: >
+          flutter test
+          test/domain
+          test/core
+          test/data
+          test/project_layout_test.dart
+          test/ui/core/widgets/actions/destructive_filled_button_test.dart
+          test/ui/core/widgets/overlays/dialog/confirm
 
   test-widget:
-    name: test-widget
+    name: test-widget (soft)
     runs-on: ubuntu-latest
     continue-on-error: true
     timeout-minutes: 30

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,3 +29,7 @@ Widget state: prefer `StatelessWidget` / `HookWidget` / `ConsumerWidget` / `Hook
 ### UI style & responsive design
 
 Reuse custom components from `lib/ui/core/widgets/`; follow desktop Fluent-inspired design language. Target: single responsive UI (desktop style wins); do not add new mobile-only Material pages. See `docs/agents/ui-style.md`.
+
+### Testing
+
+CI hard gates vs local full suite, FRB thin-edge contracts (not real FRB), UI dual-track, and shared test harness rules: `docs/agents/testing.md`.

--- a/app/l10n/app_en.arb
+++ b/app/l10n/app_en.arb
@@ -578,6 +578,7 @@
   "readerEnableAutoPlay": "Enable auto-play",
   "readerInvalidParams": "Invalid reader params: missing comic_id",
   "readerSeriesAdvancePrompt": "Turn the page again to go to the next volume",
+  "readerSeriesRetreatPrompt": "Turn the page again to go to the previous volume",
   "readerNoImages": "No images",
   "metadataTabAuthors": "Authors",
   "metadataTabTags": "Tags",

--- a/app/l10n/app_zh.arb
+++ b/app/l10n/app_zh.arb
@@ -578,6 +578,7 @@
   "readerEnableAutoPlay": "开启自动播放",
   "readerInvalidParams": "阅读参数错误：缺少 comic_id",
   "readerSeriesAdvancePrompt": "再次翻页将进入下一卷",
+  "readerSeriesRetreatPrompt": "再次翻页将进入上一卷",
   "readerNoImages": "暂无图片",
   "metadataTabAuthors": "作者",
   "metadataTabTags": "标签",

--- a/app/lib/core/l10n/app_localizations.dart
+++ b/app/lib/core/l10n/app_localizations.dart
@@ -2216,6 +2216,12 @@ abstract class AppLocalizations {
   /// **'再次翻页将进入下一卷'**
   String get readerSeriesAdvancePrompt;
 
+  /// No description provided for @readerSeriesRetreatPrompt.
+  ///
+  /// In zh, this message translates to:
+  /// **'再次翻页将进入上一卷'**
+  String get readerSeriesRetreatPrompt;
+
   /// No description provided for @readerNoImages.
   ///
   /// In zh, this message translates to:

--- a/app/lib/core/l10n/app_localizations_en.dart
+++ b/app/lib/core/l10n/app_localizations_en.dart
@@ -1212,6 +1212,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Turn the page again to go to the next volume';
 
   @override
+  String get readerSeriesRetreatPrompt =>
+      'Turn the page again to go to the previous volume';
+
+  @override
   String get readerNoImages => 'No images';
 
   @override

--- a/app/lib/core/l10n/app_localizations_zh.dart
+++ b/app/lib/core/l10n/app_localizations_zh.dart
@@ -1182,6 +1182,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get readerSeriesAdvancePrompt => '再次翻页将进入下一卷';
 
   @override
+  String get readerSeriesRetreatPrompt => '再次翻页将进入上一卷';
+
+  @override
   String get readerNoImages => '暂无图片';
 
   @override

--- a/app/lib/domain/reading/spread_index.dart
+++ b/app/lib/domain/reading/spread_index.dart
@@ -156,6 +156,25 @@ class SpreadIndex {
     return spread >= totalSpreads(mode: mode, totalPages: totalPages) - 1;
   }
 
+  static bool isOnFirstSpread({
+    required ReadingMode mode,
+    required int totalPages,
+    required int currentPageIndex,
+  }) {
+    if (totalPages <= 0 || currentPageIndex < 1) {
+      return true;
+    }
+    if (!mode.usesSpreadNavigation) {
+      return currentPageIndex <= 1;
+    }
+    final int spread = spreadIndexForPage(
+      mode: mode,
+      totalPages: totalPages,
+      pageIndex: currentPageIndex,
+    );
+    return spread <= 0;
+  }
+
   /// 阅读器会话内切换模式时，将当前页码映射到新模式的页码。
   static int remapPageForModeSwitch({
     required ReadingMode fromMode,

--- a/app/lib/ui/core/widgets/actions/ghost_button.dart
+++ b/app/lib/ui/core/widgets/actions/ghost_button.dart
@@ -131,9 +131,7 @@ class GhostButton extends StatelessWidget {
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(borderRadius),
           ),
-          foregroundColor: isEnabled
-              ? enabledForeground
-              : disabledForeground,
+          foregroundColor: isEnabled ? enabledForeground : disabledForeground,
           disabledBackgroundColor: Colors.transparent,
           splashFactory: splashFactory,
         ).copyWith(

--- a/app/lib/ui/features/reader/module/controller/reader_controller.dart
+++ b/app/lib/ui/features/reader/module/controller/reader_controller.dart
@@ -24,6 +24,9 @@ part 'reader_controller.g.dart';
 
 enum ReaderTapZone { left, center, right }
 
+/// 翻页越界切卷的二次确认方向（末页→下一卷 / 首页→上一卷）。
+enum SeriesBoundaryPrompt { none, advance, retreat }
+
 typedef ReaderControllerKey = ({
   String comicId,
   bool incognito,
@@ -48,7 +51,8 @@ abstract class ReaderState with _$ReaderState {
     @Default(false) bool showControls,
     @Default(1) int currentIndex,
     int? totalPagesOverride,
-    @Default(false) bool seriesAdvancePromptPending,
+    @Default(SeriesBoundaryPrompt.none)
+    SeriesBoundaryPrompt seriesBoundaryPrompt,
     @Default(false) bool autoPlayEnabled,
   }) = _ReaderState;
 
@@ -173,19 +177,39 @@ class ReaderController extends _$ReaderController {
     final current = state.asData?.value;
     if (current == null) return;
     ReaderState next = updater(current);
-    if (next.currentIndex != current.currentIndex &&
-        next.seriesAdvancePromptPending &&
-        !SpreadIndex.isOnLastSpread(
-          mode: next.readingMode,
-          totalPages: next.totalPages,
-          currentPageIndex: next.currentIndex,
-        )) {
-      next = next.copyWith(seriesAdvancePromptPending: false);
+    if (next.currentIndex != current.currentIndex) {
+      next = _clearStaleBoundaryPrompt(next);
     }
     if (next.currentIndex != current.currentIndex) {
       _notifyPageChanged(next.currentIndex);
     }
     state = AsyncData(next);
+  }
+
+  /// Clears advance/retreat prompt once the user leaves that boundary spread.
+  ReaderState _clearStaleBoundaryPrompt(ReaderState next) {
+    switch (next.seriesBoundaryPrompt) {
+      case SeriesBoundaryPrompt.none:
+        return next;
+      case SeriesBoundaryPrompt.advance:
+        if (SpreadIndex.isOnLastSpread(
+          mode: next.readingMode,
+          totalPages: next.totalPages,
+          currentPageIndex: next.currentIndex,
+        )) {
+          return next;
+        }
+        return next.copyWith(seriesBoundaryPrompt: SeriesBoundaryPrompt.none);
+      case SeriesBoundaryPrompt.retreat:
+        if (SpreadIndex.isOnFirstSpread(
+          mode: next.readingMode,
+          totalPages: next.totalPages,
+          currentPageIndex: next.currentIndex,
+        )) {
+          return next;
+        }
+        return next.copyWith(seriesBoundaryPrompt: SeriesBoundaryPrompt.none);
+    }
   }
 
   void toggleShowControls() {
@@ -242,42 +266,18 @@ class ReaderController extends _$ReaderController {
     if (current == null) {
       return;
     }
-    final bool onLastSpread = SpreadIndex.isOnLastSpread(
-      mode: current.readingMode,
-      totalPages: current.totalPages,
-      currentPageIndex: current.currentIndex,
+    await _requestSeriesBoundaryPage(
+      onBoundary: SpreadIndex.isOnLastSpread(
+        mode: current.readingMode,
+        totalPages: current.totalPages,
+        currentPageIndex: current.currentIndex,
+      ),
+      prompt: SeriesBoundaryPrompt.advance,
+      targetItem: navContext?.nextItem,
+      session: session,
+      router: router,
+      turnPage: nextPage,
     );
-    final ReaderComicListItem? nextItem = navContext?.nextItem;
-    if (onLastSpread && nextItem != null && session != null && router != null) {
-      if (!current.seriesAdvancePromptPending) {
-        _updateDataState(
-          (ReaderState s) => s.copyWith(seriesAdvancePromptPending: true),
-        );
-        try {
-          await ref
-              .read(readerPrefetchControllerProvider.notifier)
-              .warmOpenComic(comicId: nextItem.comicId);
-        } catch (_) {
-          // warm-open 失败不阻断提示。
-        }
-        return;
-      }
-      _updateDataState(
-        (ReaderState s) => s.copyWith(seriesAdvancePromptPending: false),
-      );
-      await ref
-          .read(readerSeriesNavigationProvider.notifier)
-          .switchComic(
-            router: router,
-            currentSession: session,
-            targetComicId: nextItem.comicId,
-          );
-      return;
-    }
-    if (onLastSpread) {
-      return;
-    }
-    nextPage();
   }
 
   void prevPage() {
@@ -292,6 +292,74 @@ class ReaderController extends _$ReaderController {
       }
       return s.copyWith(currentIndex: prev);
     });
+  }
+
+  Future<void> requestPrevPage({
+    ReaderNavContextData? navContext,
+    ReadSessionRouteParams? session,
+    GoRouter? router,
+  }) async {
+    final ReaderState? current = state.asData?.value;
+    if (current == null) {
+      return;
+    }
+    await _requestSeriesBoundaryPage(
+      onBoundary: SpreadIndex.isOnFirstSpread(
+        mode: current.readingMode,
+        totalPages: current.totalPages,
+        currentPageIndex: current.currentIndex,
+      ),
+      prompt: SeriesBoundaryPrompt.retreat,
+      targetItem: navContext?.previousItem,
+      session: session,
+      router: router,
+      turnPage: prevPage,
+    );
+  }
+
+  Future<void> _requestSeriesBoundaryPage({
+    required bool onBoundary,
+    required SeriesBoundaryPrompt prompt,
+    required ReaderComicListItem? targetItem,
+    required ReadSessionRouteParams? session,
+    required GoRouter? router,
+    required void Function() turnPage,
+  }) async {
+    final ReaderState? current = state.asData?.value;
+    if (current == null) {
+      return;
+    }
+    if (onBoundary && targetItem != null && session != null && router != null) {
+      if (current.seriesBoundaryPrompt != prompt) {
+        _updateDataState(
+          (ReaderState s) => s.copyWith(seriesBoundaryPrompt: prompt),
+        );
+        try {
+          await ref
+              .read(readerPrefetchControllerProvider.notifier)
+              .warmOpenComic(comicId: targetItem.comicId);
+        } catch (_) {
+          // warm-open 失败不阻断提示。
+        }
+        return;
+      }
+      _updateDataState(
+        (ReaderState s) =>
+            s.copyWith(seriesBoundaryPrompt: SeriesBoundaryPrompt.none),
+      );
+      await ref
+          .read(readerSeriesNavigationProvider.notifier)
+          .switchComic(
+            router: router,
+            currentSession: session,
+            targetComicId: targetItem.comicId,
+          );
+      return;
+    }
+    if (onBoundary) {
+      return;
+    }
+    turnPage();
   }
 
   void setIndex(int index) {
@@ -336,7 +404,11 @@ class ReaderController extends _$ReaderController {
     GoRouter? router,
   }) async {
     if (zone == ReaderTapZone.left) {
-      prevPage();
+      await requestPrevPage(
+        navContext: navContext,
+        session: session,
+        router: router,
+      );
     } else if (zone == ReaderTapZone.right) {
       await requestNextPage(
         navContext: navContext,

--- a/app/lib/ui/features/reader/module/controller/reader_prefetch_controller.dart
+++ b/app/lib/ui/features/reader/module/controller/reader_prefetch_controller.dart
@@ -146,10 +146,7 @@ class ReaderPrefetchController extends _$ReaderPrefetchController {
       if (!isUsableReaderCacheFile(path)) {
         return null;
       }
-      return buildReaderImageProvider(
-        filePath: path,
-        cacheWidth: cacheWidth,
-      );
+      return buildReaderImageProvider(filePath: path, cacheWidth: cacheWidth);
     }
     if (imageData is! ReaderArchivePageImageData) {
       return null;
@@ -161,12 +158,10 @@ class ReaderPrefetchController extends _$ReaderPrefetchController {
       ).future,
     );
     return switch (page) {
-      ReaderPageFilePath(:final String path) => isUsableReaderCacheFile(path)
-          ? buildReaderImageProvider(
-              filePath: path,
-              cacheWidth: cacheWidth,
-            )
-          : null,
+      ReaderPageFilePath(:final String path) =>
+        isUsableReaderCacheFile(path)
+            ? buildReaderImageProvider(filePath: path, cacheWidth: cacheWidth)
+            : null,
       ReaderPageBytes(:final Uint8List data) => buildReaderImageProvider(
         memoryBytes: data,
         cacheWidth: cacheWidth,

--- a/app/lib/ui/features/reader/module/view/reader_viewport_host.dart
+++ b/app/lib/ui/features/reader/module/view/reader_viewport_host.dart
@@ -14,6 +14,7 @@ class ReaderViewportHost extends StatelessWidget {
     required this.preferredPageIndex,
     required this.readingMode,
     this.onRequestNextPage,
+    this.onRequestPrevPage,
   });
 
   final String comicId;
@@ -23,6 +24,7 @@ class ReaderViewportHost extends StatelessWidget {
   final int? preferredPageIndex;
   final ReadingMode readingMode;
   final Future<void> Function()? onRequestNextPage;
+  final Future<void> Function()? onRequestPrevPage;
 
   @override
   Widget build(BuildContext context) {
@@ -43,6 +45,7 @@ class ReaderViewportHost extends StatelessWidget {
         initialPage: initialPage,
         preferredPageIndex: preferredPageIndex,
         onRequestNextPage: onRequestNextPage,
+        onRequestPrevPage: onRequestPrevPage,
       );
     }
     return PagedViewport(
@@ -52,6 +55,7 @@ class ReaderViewportHost extends StatelessWidget {
       initialPage: initialPage,
       preferredPageIndex: preferredPageIndex,
       onRequestNextPage: onRequestNextPage,
+      onRequestPrevPage: onRequestPrevPage,
     );
   }
 }

--- a/app/lib/ui/features/reader/module/widgets/viewport/dual_page_viewport.dart
+++ b/app/lib/ui/features/reader/module/widgets/viewport/dual_page_viewport.dart
@@ -26,6 +26,7 @@ class DualPageViewport extends HookConsumerWidget {
     required this.initialPage,
     required this.preferredPageIndex,
     this.onRequestNextPage,
+    this.onRequestPrevPage,
   });
 
   final String comicId;
@@ -35,6 +36,7 @@ class DualPageViewport extends HookConsumerWidget {
   final int initialPage;
   final int? preferredPageIndex;
   final Future<void> Function()? onRequestNextPage;
+  final Future<void> Function()? onRequestPrevPage;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -226,7 +228,11 @@ class DualPageViewport extends HookConsumerWidget {
                 controller.nextPage();
               }
             } else {
-              controller.prevPage();
+              if (onRequestPrevPage != null) {
+                unawaited(onRequestPrevPage!());
+              } else {
+                controller.prevPage();
+              }
             }
           },
           child: PageView.builder(

--- a/app/lib/ui/features/reader/module/widgets/viewport/paged_viewport.dart
+++ b/app/lib/ui/features/reader/module/widgets/viewport/paged_viewport.dart
@@ -23,6 +23,7 @@ class PagedViewport extends HookConsumerWidget {
     required this.initialPage,
     required this.preferredPageIndex,
     this.onRequestNextPage,
+    this.onRequestPrevPage,
   });
 
   final String comicId;
@@ -31,6 +32,7 @@ class PagedViewport extends HookConsumerWidget {
   final int initialPage;
   final int? preferredPageIndex;
   final Future<void> Function()? onRequestNextPage;
+  final Future<void> Function()? onRequestPrevPage;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -200,7 +202,11 @@ class PagedViewport extends HookConsumerWidget {
                 notifier.nextPage();
               }
             } else {
-              notifier.prevPage();
+              if (onRequestPrevPage != null) {
+                unawaited(onRequestPrevPage!());
+              } else {
+                notifier.prevPage();
+              }
             }
           },
           child: PageView.builder(

--- a/app/lib/ui/features/reader/views/reader_page/reader_page.dart
+++ b/app/lib/ui/features/reader/views/reader_page/reader_page.dart
@@ -155,10 +155,11 @@ class ReaderPage extends HookConsumerWidget {
     );
     final ObjectRef<bool> hasAppliedKeepControls = useRef<bool>(false);
     final bool readerFullscreen = ref.watch(readerFullscreenControllerProvider);
-    final bool seriesAdvancePromptPending = ref.watch(
+    final SeriesBoundaryPrompt seriesBoundaryPrompt = ref.watch(
       readerControllerProvider(viewKey).select(
         (AsyncValue<ReaderState> asyncState) =>
-            asyncState.asData?.value.seriesAdvancePromptPending ?? false,
+            asyncState.asData?.value.seriesBoundaryPrompt ??
+            SeriesBoundaryPrompt.none,
       ),
     );
     final GlobalKey<ScaffoldState> scaffoldKey = useMemoized(
@@ -192,17 +193,27 @@ class ReaderPage extends HookConsumerWidget {
     }, <Object?>[keepControlsOpen, readerReady, controller]);
 
     useEffect(() {
-      if (!seriesAdvancePromptPending) {
+      if (seriesBoundaryPrompt == SeriesBoundaryPrompt.none) {
         return null;
       }
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!context.mounted) {
           return;
         }
-        showInfoToast(context, context.l10n.readerSeriesAdvancePrompt);
+        final String message = switch (seriesBoundaryPrompt) {
+          SeriesBoundaryPrompt.advance =>
+            context.l10n.readerSeriesAdvancePrompt,
+          SeriesBoundaryPrompt.retreat =>
+            context.l10n.readerSeriesRetreatPrompt,
+          SeriesBoundaryPrompt.none => '',
+        };
+        if (message.isEmpty) {
+          return;
+        }
+        showInfoToast(context, message);
       });
       return null;
-    }, <Object?>[seriesAdvancePromptPending, context]);
+    }, <Object?>[seriesBoundaryPrompt, context]);
 
     void dispatchReaderKeyboard(LogicalKeyboardKey key) {
       final bool showControls =
@@ -221,7 +232,16 @@ class ReaderPage extends HookConsumerWidget {
       }
       switch (command) {
         case ReaderKeyboardCommand.prevPage:
-          controller.prevPage();
+          final ReaderPageShellData? shell = shellAsync.asData?.value;
+          unawaited(
+            controller.requestPrevPage(
+              navContext: shell != null && shell.sessionContext.hasSeriesContext
+                  ? shell.sessionContext.navContext
+                  : null,
+              session: routeContext.session,
+              router: GoRouter.of(context),
+            ),
+          );
         case ReaderKeyboardCommand.nextPage:
           final ReaderPageShellData? shell = shellAsync.asData?.value;
           unawaited(
@@ -384,6 +404,11 @@ class _ReaderContentSlot extends ConsumerWidget {
       session: routeContext.session,
       router: GoRouter.of(context),
     );
+    Future<void> requestPrevPage() => controller.requestPrevPage(
+      navContext: seriesNavContext,
+      session: routeContext.session,
+      router: GoRouter.of(context),
+    );
 
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
@@ -413,6 +438,7 @@ class _ReaderContentSlot extends ConsumerWidget {
         preferredPageIndex: preferredPageIndex,
         readingMode: readingMode,
         onRequestNextPage: requestNextPage,
+        onRequestPrevPage: requestPrevPage,
       ),
     );
   }
@@ -508,6 +534,11 @@ class _ReaderBottomBarSlot extends ConsumerWidget {
       session: routeContext.session,
       router: GoRouter.of(context),
     );
+    Future<void> requestPrevPage() => controller.requestPrevPage(
+      navContext: seriesNavContext,
+      session: routeContext.session,
+      router: GoRouter.of(context),
+    );
 
     return ReaderBottomBar(
       showControls: chrome.showControls,
@@ -515,7 +546,9 @@ class _ReaderBottomBarSlot extends ConsumerWidget {
       totalPages: totalPages,
       readerAutoPlayEnabled: readerAutoPlayEnabled,
       showAutoPlayControls: chrome.readingMode.supportsAutoPlay,
-      onPrevPage: controller.prevPage,
+      onPrevPage: () {
+        unawaited(requestPrevPage());
+      },
       onNextPage: requestNextPage,
       onSetIndex: controller.setIndex,
       onReaderAutoPlayEnabledChanged: (bool value) {

--- a/app/lib/ui/features/reader/views/reader_page/widgets/reader_content.dart
+++ b/app/lib/ui/features/reader/views/reader_page/widgets/reader_content.dart
@@ -18,6 +18,7 @@ class ReaderContent extends HookConsumerWidget {
     required this.preferredPageIndex,
     required this.readingMode,
     this.onRequestNextPage,
+    this.onRequestPrevPage,
   });
 
   final String comicId;
@@ -27,6 +28,7 @@ class ReaderContent extends HookConsumerWidget {
   final int? preferredPageIndex;
   final ReadingMode readingMode;
   final Future<void> Function()? onRequestNextPage;
+  final Future<void> Function()? onRequestPrevPage;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -85,6 +87,7 @@ class ReaderContent extends HookConsumerWidget {
           preferredPageIndex: preferredPageIndex,
           readingMode: readingMode,
           onRequestNextPage: onRequestNextPage,
+          onRequestPrevPage: onRequestPrevPage,
         ),
       ),
     );

--- a/app/lib/ui/providers/comic_cover_providers.dart
+++ b/app/lib/ui/providers/comic_cover_providers.dart
@@ -126,10 +126,18 @@ class ComicCover extends _$ComicCover {
     state = ComicCoverLoading(previous: previous);
     _loadInFlight = true;
     try {
+      if (!ref.mounted) {
+        return;
+      }
+      // Capture deps before the gate wait — provider may dispose while queued.
+      final comicRepo = ref.read(comicRepoProvider);
+      final thumbRepo = ref.read(comicThumbnailRepoProvider);
+
       await ComicCoverLoadGate.run(() async {
-        final Comic? comic = await ref
-            .read(comicRepoProvider)
-            .findById(comicId);
+        if (!ref.mounted) {
+          return;
+        }
+        final Comic? comic = await comicRepo.findById(comicId);
         if (!ref.mounted) {
           return;
         }
@@ -138,13 +146,12 @@ class ComicCover extends _$ComicCover {
           return;
         }
 
-        final repo = ref.read(comicThumbnailRepoProvider);
-        Uint8List? bytes = (await repo.findByComicId(comicId))?.thumbnail;
+        Uint8List? bytes = (await thumbRepo.findByComicId(comicId))?.thumbnail;
         if (!ref.mounted) {
           return;
         }
         if (bytes == null || bytes.isEmpty) {
-          final ensured = await repo.ensureByComicId(
+          final ensured = await thumbRepo.ensureByComicId(
             comicId: comicId,
             priority: _priority,
           );
@@ -161,15 +168,16 @@ class ComicCover extends _$ComicCover {
         state = ComicCoverReady(ComicCoverImage.bytes(bytes));
       });
     } on Object catch (error, stackTrace) {
+      if (!ref.mounted) {
+        return;
+      }
       logError(
         AppLog.ui('comic_cover'),
         '加载漫画封面失败: comicId=$comicId',
         error,
         stackTrace,
       );
-      if (ref.mounted) {
-        state = ComicCoverError(cause: error);
-      }
+      state = ComicCoverError(cause: error);
     } finally {
       _loadInFlight = false;
     }

--- a/app/test/data/adapters/history_frb_mapper_test.dart
+++ b/app/test/data/adapters/history_frb_mapper_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hentai_library/data/adapters/history_frb_mapper.dart';
+import 'package:hentai_library/domain/models/models.dart' as entity;
+import 'package:hentai_library/src/rust/api/history.dart' as rust;
+import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
+
+void main() {
+  test('mapReadingHistoryDto maps Reading history fields and epoch ms', () {
+    final rust.ReadingHistoryDto dto = rust.ReadingHistoryDto(
+      comicId: 'c1',
+      title: 'Title A',
+      lastReadTimeMs: PlatformInt64Util.from(1_700_000_000_000),
+      pageIndex: 3,
+    );
+
+    final entity.ReadingHistory mapped = mapReadingHistoryDto(dto);
+
+    expect(mapped.comicId, 'c1');
+    expect(mapped.title, 'Title A');
+    expect(mapped.pageIndex, 3);
+    expect(
+      mapped.lastReadTime,
+      DateTime.fromMillisecondsSinceEpoch(1_700_000_000_000),
+    );
+  });
+
+  test('mapReadingHistoryDto allows null pageIndex', () {
+    final rust.ReadingHistoryDto dto = rust.ReadingHistoryDto(
+      comicId: 'c2',
+      title: 'Empty page',
+      lastReadTimeMs: PlatformInt64Util.from(0),
+    );
+
+    expect(mapReadingHistoryDto(dto).pageIndex, isNull);
+  });
+
+  test('toReadingHistoryDto round-trips domain Reading history', () {
+    final entity.ReadingHistory history = entity.ReadingHistory(
+      comicId: 'c3',
+      title: 'Round trip',
+      lastReadTime: DateTime.fromMillisecondsSinceEpoch(42),
+      pageIndex: 1,
+    );
+
+    final rust.ReadingHistoryDto dto = toReadingHistoryDto(history);
+    final entity.ReadingHistory again = mapReadingHistoryDto(dto);
+
+    expect(again.comicId, history.comicId);
+    expect(again.title, history.title);
+    expect(again.pageIndex, history.pageIndex);
+    expect(again.lastReadTime, history.lastReadTime);
+  });
+
+  test('mapPagedReadingHistory uses caller page and pageSize', () {
+    final rust.PagedReadingHistoryDto dto = rust.PagedReadingHistoryDto(
+      items: <rust.ReadingHistoryDto>[
+        rust.ReadingHistoryDto(
+          comicId: 'c1',
+          title: 'A',
+          lastReadTimeMs: PlatformInt64Util.from(10),
+        ),
+      ],
+      totalCount: PlatformInt64Util.from(9),
+    );
+
+    final result = mapPagedReadingHistory(dto, 2, 5);
+
+    expect(result.items, hasLength(1));
+    expect(result.items.single.comicId, 'c1');
+    expect(result.totalCount, 9);
+    expect(result.page, 2);
+    expect(result.pageSize, 5);
+  });
+}

--- a/app/test/data/adapters/reader_frb_mapper_test.dart
+++ b/app/test/data/adapters/reader_frb_mapper_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hentai_library/data/adapters/reader_frb_mapper.dart';
+import 'package:hentai_library/domain/models/enums.dart';
+import 'package:hentai_library/domain/reading/read_session_exceptions.dart';
+import 'package:hentai_library/src/rust/api/init.dart';
+
+void main() {
+  test('mapResourceType covers every ResourceType wire token', () {
+    expect(mapResourceType(ResourceType.dir), 'dir');
+    expect(mapResourceType(ResourceType.zip), 'zip');
+    expect(mapResourceType(ResourceType.cbz), 'cbz');
+    expect(mapResourceType(ResourceType.epub), 'epub');
+    expect(mapResourceType(ResourceType.cbr), 'cbr');
+    expect(mapResourceType(ResourceType.rar), 'rar');
+    expect(mapResourceType(ResourceType.cb7), 'cb7');
+    expect(mapResourceType(ResourceType.sevenZ), 'sevenz');
+    expect(mapResourceType(ResourceType.pdf), 'pdf');
+  });
+
+  test('throwReaderException wraps HentaiErrorDto as page load failure', () {
+    const HentaiErrorDto error = HentaiErrorDto(
+      code: 'Validation',
+      message: 'broken archive',
+      context: null,
+    );
+
+    expect(
+      () => throwReaderException(error, comicId: 'c1', path: '/tmp/a.cbz'),
+      throwsA(
+        isA<ReadSessionPageLoadException>()
+            .having(
+              (ReadSessionPageLoadException e) => e.message,
+              'message',
+              contains('comicId=c1'),
+            )
+            .having(
+              (ReadSessionPageLoadException e) => e.message,
+              'message',
+              contains('path=/tmp/a.cbz'),
+            )
+            .having(
+              (ReadSessionPageLoadException e) => e.cause,
+              'cause',
+              same(error),
+            ),
+      ),
+    );
+  });
+
+  test('throwReaderException defaults empty comicId and path', () {
+    const HentaiErrorDto error = HentaiErrorDto(
+      code: 'Validation',
+      message: 'x',
+      context: null,
+    );
+
+    expect(
+      () => throwReaderException(error),
+      throwsA(
+        isA<ReadSessionPageLoadException>().having(
+          (ReadSessionPageLoadException e) => e.message,
+          'message',
+          '加载漫画页面失败: comicId=, path=',
+        ),
+      ),
+    );
+  });
+}

--- a/app/test/data/adapters/series_frb_mapper_test.dart
+++ b/app/test/data/adapters/series_frb_mapper_test.dart
@@ -1,0 +1,226 @@
+import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hentai_library/data/adapters/series_frb_mapper.dart';
+import 'package:hentai_library/domain/library/library_series_projection.dart';
+import 'package:hentai_library/domain/library/library_series_sort_option.dart';
+import 'package:hentai_library/domain/models/entity/comic/series.dart';
+import 'package:hentai_library/domain/models/entity/comic/series_item.dart';
+import 'package:hentai_library/domain/models/enums.dart';
+import 'package:hentai_library/domain/models/value_objects/paged_result.dart';
+import 'package:hentai_library/domain/models/value_objects/series_comics_metadata.dart';
+import 'package:hentai_library/domain/reading/series_reading_context.dart';
+import 'package:hentai_library/src/rust/api/series.dart' as rust_series;
+
+void main() {
+  test('mapRustSeries maps Series DTO including locks and items', () {
+    const rust_series.SeriesDto dto = rust_series.SeriesDto(
+      seriesId: 's1',
+      folderPath: '/lib/series-a',
+      name: 'Series A',
+      serializationStatus: 'ongoing',
+      totalCount: 12,
+      locks: rust_series.SeriesMetaLocksDto(
+        name: true,
+        serializationStatus: false,
+        totalCount: true,
+      ),
+      items: <rust_series.SeriesItemDto>[
+        rust_series.SeriesItemDto(
+          seriesId: 's1',
+          comicId: 'c1',
+          sortOrder: 1.5,
+          sortOrderLocked: true,
+        ),
+      ],
+    );
+
+    final Series mapped = mapRustSeries(dto);
+
+    expect(mapped.id, 's1');
+    expect(mapped.name, 'Series A');
+    expect(mapped.folderPath, '/lib/series-a');
+    expect(mapped.serializationStatus, SerializationStatus.ongoing);
+    expect(mapped.totalCount, 12);
+    expect(mapped.locks.name, isTrue);
+    expect(mapped.locks.serializationStatus, isFalse);
+    expect(mapped.locks.totalCount, isTrue);
+    expect(mapped.items, hasLength(1));
+    expect(mapped.items.single.comicId, 'c1');
+    expect(mapped.items.single.order, 1.5);
+    expect(mapped.items.single.sortOrderLocked, isTrue);
+  });
+
+  test(
+    'mapRustSeries treats unknown serializationStatus and null totalCount',
+    () {
+      const rust_series.SeriesDto dto = rust_series.SeriesDto(
+        seriesId: 's2',
+        folderPath: '/x',
+        name: 'X',
+        serializationStatus: 'weird',
+        locks: rust_series.SeriesMetaLocksDto(
+          name: false,
+          serializationStatus: false,
+          totalCount: false,
+        ),
+        items: <rust_series.SeriesItemDto>[],
+      );
+
+      final Series mapped = mapRustSeries(dto);
+      expect(mapped.serializationStatus, SerializationStatus.unknown);
+      expect(mapped.totalCount, isNull);
+      expect(mapped.items, isEmpty);
+    },
+  );
+
+  test('mapRustSeriesItem maps order and lock flag', () {
+    const rust_series.SeriesItemDto dto = rust_series.SeriesItemDto(
+      seriesId: 's1',
+      comicId: 'c9',
+      sortOrder: 0,
+      sortOrderLocked: false,
+    );
+
+    final SeriesItem item = mapRustSeriesItem(dto);
+    expect(item.comicId, 'c9');
+    expect(item.order, 0);
+    expect(item.sortOrderLocked, isFalse);
+  });
+
+  test('mapRustSeriesReadingContext copies ordered comic ids', () {
+    const rust_series.SeriesReadingContextDto dto =
+        rust_series.SeriesReadingContextDto(
+          seriesId: 's1',
+          seriesName: 'Series',
+          orderedComicIds: <String>['a', 'b'],
+          currentIndex: 1,
+        );
+
+    final SeriesReadingContext ctx = mapRustSeriesReadingContext(dto);
+    expect(ctx.seriesId, 's1');
+    expect(ctx.seriesName, 'Series');
+    expect(ctx.orderedComicIds, <String>['a', 'b']);
+    expect(ctx.currentIndex, 1);
+  });
+
+  test('mapRustSeriesComicsMetadata maps facet lists and hasR18', () {
+    const rust_series.SeriesComicsMetadataDto dto =
+        rust_series.SeriesComicsMetadataDto(
+          authors: <String>['Alice'],
+          tags: <String>['tag'],
+          hasR18: true,
+          languages: <String>['zh'],
+          parodies: <String>['p'],
+          characters: <String>['c'],
+        );
+
+    final SeriesComicsMetadata meta = mapRustSeriesComicsMetadata(dto);
+    expect(meta.authors, <String>['Alice']);
+    expect(meta.tags, <String>['tag']);
+    expect(meta.hasR18, isTrue);
+    expect(meta.languages, <String>['zh']);
+    expect(meta.parodies, <String>['p']);
+    expect(meta.characters, <String>['c']);
+  });
+
+  test('mapLibrarySeriesFilter forwards Series list filter fields', () {
+    const LibrarySeriesFilter filter = LibrarySeriesFilter(
+      showR18: true,
+      r18Only: false,
+      query: 'foo',
+      requireItems: false,
+      serializationStatus: 'ongoing',
+      preferLibraryRootSeries: false,
+    );
+
+    final rust_series.SeriesFilterDto mapped = mapLibrarySeriesFilter(filter);
+    expect(mapped.showR18, isTrue);
+    expect(mapped.r18Only, isFalse);
+    expect(mapped.query, 'foo');
+    expect(mapped.requireItems, isFalse);
+    expect(mapped.serializationStatus, 'ongoing');
+    expect(mapped.preferLibraryRootSeries, isFalse);
+    expect(mapped.libraryId, isNull);
+  });
+
+  test('mapSeriesSortOption maps each Series sort field', () {
+    expect(
+      mapSeriesSortOption(
+        sortOption: const LibrarySeriesSortOption(
+          field: LibrarySeriesSortField.name,
+          descending: true,
+        ),
+      ),
+      const rust_series.SeriesSortOptionDto(
+        field: rust_series.SeriesSortFieldDto.name,
+        descending: true,
+      ),
+    );
+    expect(
+      mapSeriesSortOption(
+        sortOption: const LibrarySeriesSortOption(
+          field: LibrarySeriesSortField.comicCount,
+        ),
+      ).field,
+      rust_series.SeriesSortFieldDto.comicCount,
+    );
+    expect(
+      mapSeriesSortOption(
+        sortOption: const LibrarySeriesSortOption(
+          field: LibrarySeriesSortField.random,
+        ),
+      ).field,
+      rust_series.SeriesSortFieldDto.random,
+    );
+  });
+
+  test('mapPagedSeriesResult maps page of Series', () {
+    final rust_series.PagedSeriesResultDto page =
+        rust_series.PagedSeriesResultDto(
+          items: const <rust_series.SeriesDto>[
+            rust_series.SeriesDto(
+              seriesId: 's1',
+              folderPath: '/a',
+              name: 'A',
+              serializationStatus: 'ended',
+              locks: rust_series.SeriesMetaLocksDto(
+                name: false,
+                serializationStatus: false,
+                totalCount: false,
+              ),
+              items: <rust_series.SeriesItemDto>[],
+            ),
+          ],
+          totalCount: PlatformInt64Util.from(3),
+          page: 0,
+          pageSize: 20,
+        );
+
+    final PagedResult<Series> mapped = mapPagedSeriesResult(page);
+    expect(mapped.items.single.id, 's1');
+    expect(mapped.items.single.serializationStatus, SerializationStatus.ended);
+    expect(mapped.totalCount, 3);
+    expect(mapped.page, 0);
+    expect(mapped.pageSize, 20);
+  });
+
+  test('mapSeriesPageRequest maps PageRequest', () {
+    final mapped = mapSeriesPageRequest((page: 1, pageSize: 40));
+    expect(mapped.page, 1);
+    expect(mapped.pageSize, 40);
+  });
+
+  test('mapUpdateSeriesUserMeta maps locks payload and clearTotalCount', () {
+    final rust_series.UpdateSeriesUserMetaDto dto = mapUpdateSeriesUserMeta(
+      name: 'Renamed',
+      serializationStatus: SerializationStatus.hiatus,
+      totalCount: 8,
+      clearTotalCount: true,
+    );
+
+    expect(dto.name, 'Renamed');
+    expect(dto.serializationStatus, 'hiatus');
+    expect(dto.totalCount, 8);
+    expect(dto.clearTotalCount, isTrue);
+  });
+}

--- a/app/test/data/adapters/thumbnail_frb_mapper_test.dart
+++ b/app/test/data/adapters/thumbnail_frb_mapper_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hentai_library/data/adapters/thumbnail_frb_mapper.dart';
+import 'package:hentai_library/domain/models/enums.dart';
+import 'package:hentai_library/domain/thumbnail/thumbnail_event.dart';
+import 'package:hentai_library/src/rust/api/thumbnail.dart' as rust;
+
+void main() {
+  test('mapThumbnailPriority maps domain priorities to FRB DTOs', () {
+    expect(
+      mapThumbnailPriority(ThumbnailPriority.critical),
+      rust.ThumbnailPriorityDto.critical,
+    );
+    expect(
+      mapThumbnailPriority(ThumbnailPriority.high),
+      rust.ThumbnailPriorityDto.high,
+    );
+    expect(
+      mapThumbnailPriority(ThumbnailPriority.low),
+      rust.ThumbnailPriorityDto.low,
+    );
+  });
+
+  test('mapThumbnailEvent maps ready event to ThumbnailReady', () {
+    final ThumbnailEvent mapped = mapThumbnailEvent(
+      const rust.ThumbnailEventDto.ready(comicId: 'comic-1'),
+    );
+
+    expect(mapped, isA<ThumbnailReady>());
+    expect((mapped as ThumbnailReady).comicId, 'comic-1');
+  });
+
+  test('mapThumbnailEvent maps progress counters', () {
+    final ThumbnailEvent mapped = mapThumbnailEvent(
+      const rust.ThumbnailEventDto.progress(done: 2, total: 5, failed: 1),
+    );
+
+    expect(mapped, isA<ThumbnailProgress>());
+    final ThumbnailProgress progress = mapped as ThumbnailProgress;
+    expect(progress.done, 2);
+    expect(progress.total, 5);
+    expect(progress.failed, 1);
+  });
+}

--- a/app/test/domain/reading/spread_index_test.dart
+++ b/app/test/domain/reading/spread_index_test.dart
@@ -155,6 +155,43 @@ void main() {
     });
   });
 
+  group('SpreadIndex.isOnFirstSpread', () {
+    test('detects first spread for paged and dualPage', () {
+      expect(
+        SpreadIndex.isOnFirstSpread(
+          mode: ReadingMode.paged,
+          totalPages: 5,
+          currentPageIndex: 1,
+        ),
+        isTrue,
+      );
+      expect(
+        SpreadIndex.isOnFirstSpread(
+          mode: ReadingMode.paged,
+          totalPages: 5,
+          currentPageIndex: 2,
+        ),
+        isFalse,
+      );
+      expect(
+        SpreadIndex.isOnFirstSpread(
+          mode: ReadingMode.dualPage,
+          totalPages: 5,
+          currentPageIndex: 1,
+        ),
+        isTrue,
+      );
+      expect(
+        SpreadIndex.isOnFirstSpread(
+          mode: ReadingMode.dualPage,
+          totalPages: 5,
+          currentPageIndex: 3,
+        ),
+        isFalse,
+      );
+    });
+  });
+
   group('SpreadIndex.remapPageForModeSwitch', () {
     test('dualPage to paged uses max page in spread', () {
       expect(

--- a/app/test/support/fakes/settings_test_fakes.dart
+++ b/app/test/support/fakes/settings_test_fakes.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hentai_library/domain/models/app_setting.dart';
+import 'package:hentai_library/ui/providers.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:riverpod/misc.dart' show Override;
+
+/// Shared Settings overrides for shell/settings widget tests.
+List<Override> settingsViewTestOverrides({
+  AppSetting Function()? settingBuilder,
+  PackageInfo? packageInfo,
+}) {
+  return <Override>[
+    settingsProvider.overrideWith(
+      () => FakeSettingsNotifier(settingBuilder: settingBuilder),
+    ),
+    packageInfoProvider.overrideWith(
+      (Ref ref) async =>
+          packageInfo ??
+          PackageInfo(
+            appName: 'Hentai Library',
+            packageName: 'hentai_library',
+            version: '1.0.0',
+            buildNumber: '1',
+          ),
+    ),
+  ];
+}
+
+class FakeSettingsNotifier extends SettingsNotifier {
+  FakeSettingsNotifier({AppSetting Function()? settingBuilder})
+    : _settingBuilder = settingBuilder;
+
+  final AppSetting Function()? _settingBuilder;
+
+  @override
+  Future<AppSetting> build() async => _settingBuilder?.call() ?? AppSetting();
+}

--- a/app/test/support/localized_test_app.dart
+++ b/app/test/support/localized_test_app.dart
@@ -3,8 +3,8 @@ import 'package:hentai_library/core/l10n/app_localizations.dart';
 
 /// Applies zh (or [locale]) AppLocalizations delegates to a [MaterialApp].
 ///
-/// Prefer spreading these onto an existing MaterialApp rather than nesting
-/// another MaterialApp.
+/// Prefer [pumpLocalizedApp] from `pump_localized_app.dart` for new widget tests.
+/// Spread these onto an existing MaterialApp only when a custom shell is required.
 ({
   List<LocalizationsDelegate<dynamic>> delegates,
   List<Locale> locales,

--- a/app/test/support/pump_localized_app.dart
+++ b/app/test/support/pump_localized_app.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hentai_library/ui/core/theme/theme.dart';
+import 'package:riverpod/misc.dart' show Override;
+
+import 'localized_test_app.dart';
+
+/// Pumps a localized [MaterialApp] (optionally wrapped in [ProviderScope]).
+///
+/// Prefer this over copy-pasting MaterialApp + l10n delegates in new widget tests.
+Future<void> pumpLocalizedApp(
+  WidgetTester tester, {
+  required Widget home,
+  Locale locale = const Locale('zh'),
+  ThemeData? theme,
+  List<Override> overrides = const <Override>[],
+  bool wrapProviderScope = false,
+}) async {
+  final config = localizedTestAppConfig(locale: locale);
+  Widget app = MaterialApp(
+    locale: config.locale,
+    localizationsDelegates: config.delegates,
+    supportedLocales: config.locales,
+    theme: theme ?? buildAppTheme(Brightness.light),
+    home: home,
+  );
+  if (wrapProviderScope || overrides.isNotEmpty) {
+    app = ProviderScope(overrides: overrides, child: app);
+  }
+  await tester.pumpWidget(app);
+}

--- a/app/test/ui/core/widgets/actions/destructive_filled_button_test.dart
+++ b/app/test/ui/core/widgets/actions/destructive_filled_button_test.dart
@@ -3,19 +3,19 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hentai_library/ui/core/theme/theme.dart';
 import 'package:hentai_library/ui/core/widgets/actions/destructive_filled_button.dart';
 
+import '../../../../support/pump_localized_app.dart';
+
 void main() {
   group('DestructiveFilledButton', () {
     testWidgets('enabled uses destructive / onDestructive fill', (
       WidgetTester tester,
     ) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: buildAppTheme(Brightness.light),
-          home: const Scaffold(
-            body: DestructiveFilledButton(
-              onPressed: _noop,
-              child: Text('Delete'),
-            ),
+      await pumpLocalizedApp(
+        tester,
+        home: const Scaffold(
+          body: DestructiveFilledButton(
+            onPressed: _noop,
+            child: Text('Delete'),
           ),
         ),
       );
@@ -26,28 +26,17 @@ void main() {
       final FilledButton button = tester.widget(find.byType(FilledButton));
       final Set<WidgetState> enabled = <WidgetState>{};
 
-      expect(
-        button.style?.backgroundColor?.resolve(enabled),
-        h.destructive,
-      );
-      expect(
-        button.style?.foregroundColor?.resolve(enabled),
-        h.onDestructive,
-      );
+      expect(button.style?.backgroundColor?.resolve(enabled), h.destructive);
+      expect(button.style?.foregroundColor?.resolve(enabled), h.onDestructive);
     });
 
     testWidgets('disabled keeps destructive family instead of grey primary', (
       WidgetTester tester,
     ) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: buildAppTheme(Brightness.light),
-          home: const Scaffold(
-            body: DestructiveFilledButton(
-              onPressed: null,
-              child: Text('Delete'),
-            ),
-          ),
+      await pumpLocalizedApp(
+        tester,
+        home: const Scaffold(
+          body: DestructiveFilledButton(onPressed: null, child: Text('Delete')),
         ),
       );
 

--- a/app/test/ui/core/widgets/overlays/context_menu/context_menu_common_test.dart
+++ b/app/test/ui/core/widgets/overlays/context_menu/context_menu_common_test.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hentai_library/ui/core/theme/theme.dart';
 import 'package:hentai_library/ui/core/widgets/overlays/context_menu/common.dart';
+
+import '../../../../../support/pump_localized_app.dart';
 
 void main() {
   testWidgets('menu top-left matches position when it fits on screen', (
@@ -10,36 +11,37 @@ void main() {
     await tester.binding.setSurfaceSize(const Size(800, 600));
     addTearDown(() => tester.binding.setSurfaceSize(null));
 
-    const Offset anchor = Offset(120, 80); // global; root overlay origin is (0,0)
+    const Offset anchor = Offset(
+      120,
+      80,
+    ); // global; root overlay origin is (0,0)
     const Key menuKey = Key('context-menu-panel');
 
-    await tester.pumpWidget(
-      MaterialApp(
-        theme: buildAppTheme(Brightness.light),
-        home: Scaffold(
-          body: Builder(
-            builder: (BuildContext context) {
-              return Center(
-                child: TextButton(
-                  onPressed: () {
-                    ContextMenuCommon.show(
-                      context,
-                      position: anchor,
+    await pumpLocalizedApp(
+      tester,
+      home: Scaffold(
+        body: Builder(
+          builder: (BuildContext context) {
+            return Center(
+              child: TextButton(
+                onPressed: () {
+                  ContextMenuCommon.show(
+                    context,
+                    position: anchor,
+                    width: 236,
+                    height: 152,
+                    builder: (VoidCallback onClose) => SizedBox(
+                      key: menuKey,
                       width: 236,
                       height: 152,
-                      builder: (VoidCallback onClose) => SizedBox(
-                        key: menuKey,
-                        width: 236,
-                        height: 152,
-                        child: const ColoredBox(color: Colors.red),
-                      ),
-                    );
-                  },
-                  child: const Text('open'),
-                ),
-              );
-            },
-          ),
+                      child: const ColoredBox(color: Colors.red),
+                    ),
+                  );
+                },
+                child: const Text('open'),
+              ),
+            );
+          },
         ),
       ),
     );

--- a/app/test/ui/core/widgets/overlays/dialog/confirm/clear_reading_history_confirm_dialog_test.dart
+++ b/app/test/ui/core/widgets/overlays/dialog/confirm/clear_reading_history_confirm_dialog_test.dart
@@ -1,22 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hentai_library/core/l10n/app_localizations.dart';
-import 'package:hentai_library/ui/core/theme/theme.dart';
 import 'package:hentai_library/ui/core/widgets/actions/destructive_filled_button.dart';
 import 'package:hentai_library/ui/core/widgets/overlays/dialog/confirm/clear_reading_history_confirm_dialog.dart';
+
+import '../../../../../../support/pump_localized_app.dart';
 
 void main() {
   testWidgets('confirm action uses DestructiveFilledButton with clear label', (
     WidgetTester tester,
   ) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        locale: const Locale('zh'),
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        theme: buildAppTheme(Brightness.light),
-        home: const Scaffold(body: ClearReadingHistoryConfirmDialog()),
-      ),
+    await pumpLocalizedApp(
+      tester,
+      home: const Scaffold(body: ClearReadingHistoryConfirmDialog()),
     );
     await tester.pumpAndSettle();
 

--- a/app/test/ui/core/widgets/overlays/dialog/confirm/comic_confirm_delete_dialog_test.dart
+++ b/app/test/ui/core/widgets/overlays/dialog/confirm/comic_confirm_delete_dialog_test.dart
@@ -1,23 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hentai_library/core/l10n/app_localizations.dart';
-import 'package:hentai_library/ui/core/theme/theme.dart';
 import 'package:hentai_library/ui/core/widgets/actions/destructive_filled_button.dart';
 import 'package:hentai_library/ui/core/widgets/overlays/dialog/confirm/comic_confirm_delete_dialog.dart';
+
+import '../../../../../../support/pump_localized_app.dart';
 
 void main() {
   testWidgets('local delete requires acknowledgement before confirm', (
     WidgetTester tester,
   ) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        locale: const Locale('zh'),
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        theme: buildAppTheme(Brightness.light),
-        home: const Scaffold(
-          body: ComicConfirmDeleteDialog(title: '本子A', isLocal: true),
-        ),
+    await pumpLocalizedApp(
+      tester,
+      home: const Scaffold(
+        body: ComicConfirmDeleteDialog(title: '本子A', isLocal: true),
       ),
     );
 
@@ -38,18 +33,11 @@ void main() {
   testWidgets(
     'remote delete shows library-only copy without acknowledgement gate',
     (WidgetTester tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          locale: const Locale('en'),
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          theme: buildAppTheme(Brightness.light),
-          home: const Scaffold(
-            body: ComicConfirmDeleteDialog(
-              title: 'Remote Comic',
-              isLocal: false,
-            ),
-          ),
+      await pumpLocalizedApp(
+        tester,
+        locale: const Locale('en'),
+        home: const Scaffold(
+          body: ComicConfirmDeleteDialog(title: 'Remote Comic', isLocal: false),
         ),
       );
 
@@ -72,15 +60,10 @@ void main() {
   testWidgets('confirm action uses DestructiveFilledButton', (
     WidgetTester tester,
   ) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        locale: const Locale('zh'),
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        theme: buildAppTheme(Brightness.light),
-        home: const Scaffold(
-          body: ComicConfirmDeleteDialog(title: '本子A', isLocal: false),
-        ),
+    await pumpLocalizedApp(
+      tester,
+      home: const Scaffold(
+        body: ComicConfirmDeleteDialog(title: '本子A', isLocal: false),
       ),
     );
 

--- a/app/test/ui/core/widgets/overlays/dialog/confirm/remove_saved_path_confirm_dialog_test.dart
+++ b/app/test/ui/core/widgets/overlays/dialog/confirm/remove_saved_path_confirm_dialog_test.dart
@@ -1,23 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hentai_library/core/l10n/app_localizations.dart';
-import 'package:hentai_library/ui/core/theme/theme.dart';
 import 'package:hentai_library/ui/core/widgets/actions/destructive_filled_button.dart';
 import 'package:hentai_library/ui/core/widgets/overlays/dialog/confirm/remove_saved_path_confirm_dialog.dart';
+
+import '../../../../../../support/pump_localized_app.dart';
 
 void main() {
   testWidgets('confirm action uses DestructiveFilledButton', (
     WidgetTester tester,
   ) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        locale: const Locale('zh'),
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        theme: buildAppTheme(Brightness.light),
-        home: const Scaffold(
-          body: RemoveSavedPathConfirmDialog(path: r'E:\comics\lib'),
-        ),
+    await pumpLocalizedApp(
+      tester,
+      home: const Scaffold(
+        body: RemoveSavedPathConfirmDialog(path: r'E:\comics\lib'),
       ),
     );
     await tester.pumpAndSettle();
@@ -25,9 +20,7 @@ void main() {
     expect(find.byType(DestructiveFilledButton), findsOneWidget);
     expect(
       tester
-          .widget<DestructiveFilledButton>(
-            find.byType(DestructiveFilledButton),
-          )
+          .widget<DestructiveFilledButton>(find.byType(DestructiveFilledButton))
           .onPressed,
       isNotNull,
     );

--- a/app/test/ui/core/widgets/overlays/dialog/confirm/tag_confirm_delete_dialog_test.dart
+++ b/app/test/ui/core/widgets/overlays/dialog/confirm/tag_confirm_delete_dialog_test.dart
@@ -1,22 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hentai_library/core/l10n/app_localizations.dart';
-import 'package:hentai_library/ui/core/theme/theme.dart';
 import 'package:hentai_library/ui/core/widgets/actions/destructive_filled_button.dart';
 import 'package:hentai_library/ui/core/widgets/overlays/dialog/confirm/tag_confirm_delete_dialog.dart';
+
+import '../../../../../../support/pump_localized_app.dart';
 
 void main() {
   testWidgets('footer action buttons use 4px corners', (
     WidgetTester tester,
   ) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        locale: const Locale('en'),
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        theme: buildAppTheme(Brightness.light),
-        home: const Scaffold(body: TagConfirmDeleteDialog(count: 1)),
-      ),
+    await pumpLocalizedApp(
+      tester,
+      locale: const Locale('en'),
+      home: const Scaffold(body: TagConfirmDeleteDialog(count: 1)),
     );
     await tester.pumpAndSettle();
 
@@ -33,14 +29,10 @@ void main() {
   testWidgets('confirm action uses DestructiveFilledButton', (
     WidgetTester tester,
   ) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        locale: const Locale('en'),
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        theme: buildAppTheme(Brightness.light),
-        home: const Scaffold(body: TagConfirmDeleteDialog(count: 1)),
-      ),
+    await pumpLocalizedApp(
+      tester,
+      locale: const Locale('en'),
+      home: const Scaffold(body: TagConfirmDeleteDialog(count: 1)),
     );
     await tester.pumpAndSettle();
 

--- a/app/test/ui/features/metadata/views/metadata_page/named_facet_management_panel_test.dart
+++ b/app/test/ui/features/metadata/views/metadata_page/named_facet_management_panel_test.dart
@@ -3,11 +3,9 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hentai_library/core/l10n/app_localizations.dart';
 import 'package:hentai_library/domain/models/value_objects/page_request.dart';
 import 'package:hentai_library/domain/models/value_objects/paged_result.dart';
 import 'package:hentai_library/domain/repositories/named_facet_management_repository.dart';
-import 'package:hentai_library/ui/core/theme/theme.dart';
 import 'package:hentai_library/ui/core/widgets/actions/destructive_filled_button.dart';
 import 'package:hentai_library/ui/core/widgets/element/chip/outlined_meta_chip.dart';
 import 'package:hentai_library/ui/core/widgets/overlays/dialog/adaptive_form_surface.dart';
@@ -18,64 +16,67 @@ import 'package:hentai_library/ui/features/metadata/views/metadata_page/widgets/
 import 'package:hentai_library/ui/features/shell/di/deps.dart';
 import 'package:riverpod/misc.dart' show Override;
 
+import '../../../../../support/pump_localized_app.dart';
+
 void main() {
   group('Named facet management panel', () {
-    testWidgets('detail shows name title, attachment metric, and footer actions', (
-      WidgetTester tester,
-    ) async {
-      await _pumpPanel(tester, repo: _FakeRepo(authors: <String>['作者 A']));
+    testWidgets(
+      'detail shows name title, attachment metric, and footer actions',
+      (WidgetTester tester) async {
+        await _pumpPanel(tester, repo: _FakeRepo(authors: <String>['作者 A']));
 
-      expect(find.byType(OutlinedMetaChip), findsOneWidget);
-      await tester.tap(find.text('作者 A'));
-      await tester.pumpAndSettle();
+        expect(find.byType(OutlinedMetaChip), findsOneWidget);
+        await tester.tap(find.text('作者 A'));
+        await tester.pumpAndSettle();
 
-      expect(find.byType(AdaptiveFormSurface), findsOneWidget);
-      expect(
-        find.descendant(
-          of: find.byType(AdaptiveFormSurface),
-          matching: find.text('作者 A'),
-        ),
-        findsOneWidget,
-      );
-      expect(find.text('名称'), findsNothing);
-      expect(find.text('附着漫画数'), findsOneWidget);
-      expect(find.text('3'), findsOneWidget);
-      expect(
-        find.textContaining('Named facet attachment count'),
-        findsNothing,
-      );
-
-      final DialogActionsBar actionsBar = tester.widget(
-        find.descendant(
-          of: find.byType(AdaptiveFormSurface),
-          matching: find.byType(DialogActionsBar),
-        ),
-      );
-      expect(actionsBar.showDivider, isFalse);
-
-      expect(find.text('关闭'), findsOneWidget);
-      expect(find.text('重命名'), findsOneWidget);
-      expect(find.text('删除'), findsOneWidget);
-
-      final ThemeData footerTheme = Theme.of(
-        tester.element(
+        expect(find.byType(AdaptiveFormSurface), findsOneWidget);
+        expect(
           find.descendant(
-            of: find.byType(DialogActionsBar),
-            matching: find.byType(Wrap),
+            of: find.byType(AdaptiveFormSurface),
+            matching: find.text('作者 A'),
           ),
-        ),
-      );
-      final OutlinedBorder? outlinedShape = footerTheme
-          .outlinedButtonTheme
-          .style
-          ?.shape
-          ?.resolve(const <WidgetState>{});
-      expect(outlinedShape, isA<RoundedRectangleBorder>());
-      expect(
-        (outlinedShape! as RoundedRectangleBorder).borderRadius,
-        BorderRadius.circular(4),
-      );
-    });
+          findsOneWidget,
+        );
+        expect(find.text('名称'), findsNothing);
+        expect(find.text('附着漫画数'), findsOneWidget);
+        expect(find.text('3'), findsOneWidget);
+        expect(
+          find.textContaining('Named facet attachment count'),
+          findsNothing,
+        );
+
+        final DialogActionsBar actionsBar = tester.widget(
+          find.descendant(
+            of: find.byType(AdaptiveFormSurface),
+            matching: find.byType(DialogActionsBar),
+          ),
+        );
+        expect(actionsBar.showDivider, isFalse);
+
+        expect(find.text('关闭'), findsOneWidget);
+        expect(find.text('重命名'), findsOneWidget);
+        expect(find.text('删除'), findsOneWidget);
+
+        final ThemeData footerTheme = Theme.of(
+          tester.element(
+            find.descendant(
+              of: find.byType(DialogActionsBar),
+              matching: find.byType(Wrap),
+            ),
+          ),
+        );
+        final OutlinedBorder? outlinedShape = footerTheme
+            .outlinedButtonTheme
+            .style
+            ?.shape
+            ?.resolve(const <WidgetState>{});
+        expect(outlinedShape, isA<RoundedRectangleBorder>());
+        expect(
+          (outlinedShape! as RoundedRectangleBorder).borderRadius,
+          BorderRadius.circular(4),
+        );
+      },
+    );
 
     testWidgets('delete stays disabled until attachment count is ready', (
       WidgetTester tester,
@@ -179,10 +180,7 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.byType(DestructiveFilledButton), findsOneWidget);
-        expect(
-          find.text('将删除「作者 A」，并解除与 3 本漫画的附着。此操作不可撤销。'),
-          findsOneWidget,
-        );
+        expect(find.text('将删除「作者 A」，并解除与 3 本漫画的附着。此操作不可撤销。'), findsOneWidget);
         expect(find.textContaining('Named facet attachment'), findsNothing);
       },
     );
@@ -223,39 +221,33 @@ Future<void> _pumpPanel(
   tester.view.devicePixelRatio = 1.0;
   addTearDown(tester.view.resetPhysicalSize);
 
-  await tester.pumpWidget(
-    ProviderScope(
-      overrides: <Override>[
-        namedFacetManagementRepoProvider.overrideWithValue(repo),
-      ],
-      child: MaterialApp(
-        locale: const Locale('zh'),
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        theme: buildAppTheme(Brightness.light),
-        home: Scaffold(
-          body: Consumer(
-            builder: (BuildContext context, WidgetRef ref, Widget? child) {
-              onRef?.call(ref);
-              return CustomScrollView(
-                slivers: <Widget>[
-                  NamedFacetManagementSliverGroup(
-                    kind: ManagedNamedFacetKind.author,
-                    layoutTier: MetadataLayoutTier.expanded,
-                    viewportWidth: 1200,
-                    horizontalPadding: metadataContentHorizontalPadding(
-                      MetadataLayoutTier.expanded,
-                    ),
-                    contentMaxWidth: metadataInnerContentMaxWidth(
-                      MetadataLayoutTier.expanded,
-                      1200,
-                    ),
-                  ),
-                ],
-              );
-            },
-          ),
-        ),
+  await pumpLocalizedApp(
+    tester,
+    wrapProviderScope: true,
+    overrides: <Override>[
+      namedFacetManagementRepoProvider.overrideWithValue(repo),
+    ],
+    home: Scaffold(
+      body: Consumer(
+        builder: (BuildContext context, WidgetRef ref, Widget? child) {
+          onRef?.call(ref);
+          return CustomScrollView(
+            slivers: <Widget>[
+              NamedFacetManagementSliverGroup(
+                kind: ManagedNamedFacetKind.author,
+                layoutTier: MetadataLayoutTier.expanded,
+                viewportWidth: 1200,
+                horizontalPadding: metadataContentHorizontalPadding(
+                  MetadataLayoutTier.expanded,
+                ),
+                contentMaxWidth: metadataInnerContentMaxWidth(
+                  MetadataLayoutTier.expanded,
+                  1200,
+                ),
+              ),
+            ],
+          );
+        },
       ),
     ),
   );

--- a/app/test/ui/features/reader/reader_controller_test.dart
+++ b/app/test/ui/features/reader/reader_controller_test.dart
@@ -1,13 +1,19 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hentai_library/domain/models/app_setting.dart';
 import 'package:hentai_library/domain/models/entity/comic/comic.dart';
 import 'package:hentai_library/domain/models/enums.dart';
+import 'package:hentai_library/domain/reading/read_session.dart';
 import 'package:hentai_library/domain/reading/read_session_page.dart';
 import 'package:hentai_library/domain/reading/reader_session_snapshot.dart';
 import 'package:hentai_library/domain/reading/reading_mode.dart';
 import 'package:hentai_library/domain/repositories/app_setting_repository.dart';
 import 'package:hentai_library/ui/features/reader/module/controller/reader_controller.dart';
+import 'package:hentai_library/ui/features/reader/module/controller/reader_prefetch_controller.dart';
+import 'package:hentai_library/ui/features/reader/module/controller/reader_series_navigation.dart';
 import 'package:hentai_library/ui/features/reader/view_models/read_session_providers.dart';
+import 'package:hentai_library/ui/features/reader/views/reader_page/widgets/reader_route_context.dart';
 import 'package:hentai_library/ui/features/settings/view_models/settings_notifier.dart';
 import 'package:hentai_library/ui/features/shell/di/repos.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -69,10 +75,90 @@ class _MemoryAppSettingRepository implements AppSettingRepository {
   Future<bool?> peekLegacyAutoScan() async => null;
 }
 
+class _RecordingSeriesNavigation extends ReaderSeriesNavigation {
+  final List<String> switchedTo = <String>[];
+
+  @override
+  void build() {}
+
+  @override
+  Future<void> switchComic({
+    required GoRouter router,
+    required ReadSessionRouteParams currentSession,
+    required String targetComicId,
+  }) async {
+    switchedTo.add(targetComicId);
+  }
+}
+
+class _FakePrefetchController extends ReaderPrefetchController {
+  final List<String> warmedOpen = <String>[];
+
+  @override
+  Map<String, int> build() => <String, int>{};
+
+  @override
+  Future<void> warmOpenComic({
+    required String comicId,
+    int? resumePageOneBased,
+  }) async {
+    warmedOpen.add(comicId);
+  }
+}
+
+GoRouter _testRouter() => GoRouter(
+  routes: <RouteBase>[
+    GoRoute(
+      path: '/',
+      builder: (BuildContext context, GoRouterState state) => const SizedBox(),
+    ),
+  ],
+);
+
+ReaderNavContextData _navContext({
+  String? previousComicId,
+  String? nextComicId,
+  String currentComicId = _comicId,
+}) {
+  final List<ReaderComicListItem> items = <ReaderComicListItem>[];
+  if (previousComicId != null) {
+    items.add(
+      ReaderComicListItem(
+        comicId: previousComicId,
+        title: 'Previous',
+        order: 0,
+      ),
+    );
+  }
+  items.add(
+    ReaderComicListItem(
+      comicId: currentComicId,
+      title: 'Current',
+      order: items.length,
+    ),
+  );
+  if (nextComicId != null) {
+    items.add(
+      ReaderComicListItem(
+        comicId: nextComicId,
+        title: 'Next',
+        order: items.length,
+      ),
+    );
+  }
+  return ReaderNavContextData(
+    items: items,
+    currentIndex: previousComicId == null ? 0 : 1,
+    preferredPageIndex: null,
+  );
+}
+
 ProviderContainer _createContainer({
   required AppSetting initialSetting,
   ReaderControllerKey key = _key,
   ReaderSessionSnapshot? snapshot,
+  _RecordingSeriesNavigation? seriesNavigation,
+  _FakePrefetchController? prefetch,
 }) {
   final ReaderSessionSnapshot session = snapshot ?? _snapshot();
   return ProviderContainer(
@@ -84,6 +170,10 @@ ProviderContainer _createContainer({
         comicId: key.comicId,
         incognito: key.incognito,
       ).overrideWith((Ref ref) async => session),
+      if (seriesNavigation != null)
+        readerSeriesNavigationProvider.overrideWith(() => seriesNavigation),
+      if (prefetch != null)
+        readerPrefetchControllerProvider.overrideWith(() => prefetch),
     ],
   );
 }
@@ -302,6 +392,150 @@ void main() {
 
       controller.setIndex(4);
       expect(_state(container, _incognitoKey)?.currentIndex, 4);
+    });
+  });
+
+  group('requestPrevPage series retreat', () {
+    const String previousComicId = 'previous-series-comic';
+    const ReadSessionRouteParams session = ReadSessionRouteParams(
+      comicId: _comicId,
+      incognito: true,
+    );
+
+    test(
+      'first call on first spread with previous comic arms retreat prompt',
+      () async {
+        final _RecordingSeriesNavigation navigation =
+            _RecordingSeriesNavigation();
+        final _FakePrefetchController prefetch = _FakePrefetchController();
+        final ProviderContainer container = _createContainer(
+          key: _incognitoKey,
+          initialSetting: AppSetting(readingMode: ReadingMode.paged),
+          snapshot: _snapshot(pageCount: 5, resumePage: 1),
+          seriesNavigation: navigation,
+          prefetch: prefetch,
+        );
+        addTearDown(container.dispose);
+
+        await container.read(readerControllerProvider(_incognitoKey).future);
+        final ReaderController controller = _controller(
+          container,
+          _incognitoKey,
+        );
+
+        await controller.requestPrevPage(
+          navContext: _navContext(previousComicId: previousComicId),
+          session: session,
+          router: _testRouter(),
+        );
+
+        expect(
+          _state(container, _incognitoKey)?.seriesBoundaryPrompt,
+          SeriesBoundaryPrompt.retreat,
+        );
+        expect(_state(container, _incognitoKey)?.currentIndex, 1);
+        expect(prefetch.warmedOpen, <String>[previousComicId]);
+        expect(navigation.switchedTo, isEmpty);
+      },
+    );
+
+    test('second call on first spread switches to previous comic', () async {
+      final _RecordingSeriesNavigation navigation =
+          _RecordingSeriesNavigation();
+      final _FakePrefetchController prefetch = _FakePrefetchController();
+      final ProviderContainer container = _createContainer(
+        key: _incognitoKey,
+        initialSetting: AppSetting(readingMode: ReadingMode.paged),
+        snapshot: _snapshot(pageCount: 5, resumePage: 1),
+        seriesNavigation: navigation,
+        prefetch: prefetch,
+      );
+      addTearDown(container.dispose);
+
+      await container.read(readerControllerProvider(_incognitoKey).future);
+      final ReaderController controller = _controller(container, _incognitoKey);
+      final GoRouter router = _testRouter();
+      final ReaderNavContextData nav = _navContext(
+        previousComicId: previousComicId,
+      );
+
+      await controller.requestPrevPage(
+        navContext: nav,
+        session: session,
+        router: router,
+      );
+      await controller.requestPrevPage(
+        navContext: nav,
+        session: session,
+        router: router,
+      );
+
+      expect(navigation.switchedTo, <String>[previousComicId]);
+      expect(
+        _state(container, _incognitoKey)?.seriesBoundaryPrompt,
+        SeriesBoundaryPrompt.none,
+      );
+    });
+
+    test('on first spread without previous comic is a no-op', () async {
+      final _RecordingSeriesNavigation navigation =
+          _RecordingSeriesNavigation();
+      final ProviderContainer container = _createContainer(
+        key: _incognitoKey,
+        initialSetting: AppSetting(readingMode: ReadingMode.paged),
+        snapshot: _snapshot(pageCount: 5, resumePage: 1),
+        seriesNavigation: navigation,
+        prefetch: _FakePrefetchController(),
+      );
+      addTearDown(container.dispose);
+
+      await container.read(readerControllerProvider(_incognitoKey).future);
+      final ReaderController controller = _controller(container, _incognitoKey);
+
+      await controller.requestPrevPage(
+        navContext: _navContext(),
+        session: session,
+        router: _testRouter(),
+      );
+
+      expect(
+        _state(container, _incognitoKey)?.seriesBoundaryPrompt,
+        SeriesBoundaryPrompt.none,
+      );
+      expect(_state(container, _incognitoKey)?.currentIndex, 1);
+      expect(navigation.switchedTo, isEmpty);
+    });
+
+    test('leaving first spread clears retreat prompt', () async {
+      final ProviderContainer container = _createContainer(
+        key: _incognitoKey,
+        initialSetting: AppSetting(readingMode: ReadingMode.paged),
+        snapshot: _snapshot(pageCount: 5, resumePage: 1),
+        seriesNavigation: _RecordingSeriesNavigation(),
+        prefetch: _FakePrefetchController(),
+      );
+      addTearDown(container.dispose);
+
+      await container.read(readerControllerProvider(_incognitoKey).future);
+      final ReaderController controller = _controller(container, _incognitoKey);
+
+      await controller.requestPrevPage(
+        navContext: _navContext(previousComicId: previousComicId),
+        session: session,
+        router: _testRouter(),
+      );
+      expect(
+        _state(container, _incognitoKey)?.seriesBoundaryPrompt,
+        SeriesBoundaryPrompt.retreat,
+      );
+
+      controller.nextPage();
+
+      expect(
+        _state(container, _incognitoKey)?.seriesBoundaryPrompt,
+        SeriesBoundaryPrompt.none,
+      );
+      expect(_state(container, _incognitoKey)?.currentIndex, 2);
     });
   });
 }

--- a/app/test/ui/features/settings/app_update_check_test.dart
+++ b/app/test/ui/features/settings/app_update_check_test.dart
@@ -1,18 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hentai_library/core/l10n/app_localizations.dart';
 import 'package:hentai_library/core/util/semver_utils.dart';
 import 'package:hentai_library/data/services/app_update/app_update_service.dart';
 import 'package:hentai_library/domain/models/app_release_info.dart';
-import 'package:hentai_library/domain/models/app_setting.dart';
 import 'package:hentai_library/ui/core/widgets/overlays/dialog/app_update_dialog.dart';
 import 'package:hentai_library/ui/features/settings/state/app_update_controller.dart';
-import 'package:hentai_library/ui/features/settings/view_models/settings_notifier.dart';
 import 'package:hentai_library/ui/features/shell/di/services.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:package_info_plus/package_info_plus.dart';
 import 'package:riverpod/misc.dart' show Override;
+
+import '../../../support/fakes/settings_test_fakes.dart';
+import '../../../support/pump_localized_app.dart';
 
 class MockAppUpdateService extends Mock implements AppUpdateService {}
 
@@ -49,10 +48,11 @@ void main() {
         () => mockService.fetchLatestStableRelease(),
       ).thenAnswer((_) async => newerRelease);
 
-      await tester.pumpWidget(_buildHarness(mockService: mockService));
+      await _pumpHarness(tester, mockService: mockService);
       await tester.tap(find.text('检查更新'));
       await tester.pumpAndSettle();
 
+      expect(tester.takeException(), isNull);
       expect(find.byType(AppUpdateDialog), findsOneWidget);
       expect(find.text('发现新版本 v1.0.1'), findsOneWidget);
     });
@@ -72,10 +72,11 @@ void main() {
           () => mockService.fetchLatestStableRelease(),
         ).thenAnswer((_) async => olderRelease);
 
-        await tester.pumpWidget(_buildHarness(mockService: mockService));
+        await _pumpHarness(tester, mockService: mockService);
         await tester.tap(find.text('检查更新'));
         await tester.pumpAndSettle();
 
+        expect(tester.takeException(), isNull);
         expect(find.byType(AppUpdateDialog), findsNothing);
         expect(find.text('当前已是最新版本'), findsOneWidget);
       },
@@ -96,11 +97,10 @@ void main() {
           () => mockService.fetchLatestStableRelease(),
         ).thenAnswer((_) async => newerRelease);
 
-        await tester.pumpWidget(
-          ProviderScope(
-            overrides: _overrides(mockService),
-            child: const MaterialApp(home: SizedBox.shrink()),
-          ),
+        await pumpLocalizedApp(
+          tester,
+          home: const SizedBox.shrink(),
+          overrides: _overrides(mockService),
         );
 
         final ProviderContainer container = ProviderScope.containerOf(
@@ -111,55 +111,38 @@ void main() {
             .runManualCheck();
         await tester.pumpAndSettle();
 
+        expect(tester.takeException(), isNull);
         expect(find.byType(AppUpdateDialog), findsNothing);
       },
     );
   });
 }
 
-Widget _buildHarness({required MockAppUpdateService mockService}) {
-  return ProviderScope(
+Future<void> _pumpHarness(
+  WidgetTester tester, {
+  required MockAppUpdateService mockService,
+}) {
+  return pumpLocalizedApp(
+    tester,
     overrides: _overrides(mockService),
-    child: MaterialApp(
-      locale: const Locale('zh'),
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      home: Builder(
-        builder: (BuildContext context) {
-          return ElevatedButton(
-            onPressed: () async {
-              await ProviderScope.containerOf(context)
-                  .read(appUpdateControllerProvider.notifier)
-                  .runManualCheck(context: context);
-            },
-            child: const Text('检查更新'),
-          );
-        },
-      ),
+    home: Builder(
+      builder: (BuildContext context) {
+        return ElevatedButton(
+          onPressed: () async {
+            await ProviderScope.containerOf(context)
+                .read(appUpdateControllerProvider.notifier)
+                .runManualCheck(context: context);
+          },
+          child: const Text('检查更新'),
+        );
+      },
     ),
   );
 }
 
 List<Override> _overrides(MockAppUpdateService mockService) {
-  return [
+  return <Override>[
     appUpdateServiceProvider.overrideWithValue(mockService),
-    packageInfoProvider.overrideWith(
-      (Ref ref) => Future<PackageInfo>.value(
-        PackageInfo(
-          appName: 'hentai_library',
-          packageName: 'hentai_library',
-          version: '1.0.0',
-          buildNumber: '1',
-          buildSignature: '',
-          installerStore: '',
-        ),
-      ),
-    ),
-    settingsProvider.overrideWith(() => _FakeSettingsNotifier()),
+    ...settingsViewTestOverrides(),
   ];
-}
-
-class _FakeSettingsNotifier extends SettingsNotifier {
-  @override
-  Future<AppSetting> build() async => AppSetting();
 }

--- a/app/test/ui/features/settings/views/settings_page/settings_responsive_test.dart
+++ b/app/test/ui/features/settings/views/settings_page/settings_responsive_test.dart
@@ -1,16 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hentai_library/core/l10n/app_localizations.dart';
-import 'package:hentai_library/domain/models/app_setting.dart';
-import 'package:hentai_library/ui/core/theme/theme.dart';
-import 'package:hentai_library/ui/providers.dart';
 import 'package:hentai_library/ui/features/settings/views/settings_page/widgets/settings_loaded_view.dart';
 import 'package:hentai_library/ui/features/settings/views/settings_page/widgets/settings_layout_constants.dart';
 import 'package:hentai_library/ui/features/settings/views/settings_page/widgets/settings_page_header.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
-import 'package:package_info_plus/package_info_plus.dart';
-import 'package:riverpod/misc.dart' show Override;
+
+import '../../../../../support/fakes/settings_test_fakes.dart';
+import '../../../../../support/pump_localized_app.dart';
 
 void main() {
   group('Settings responsive layout', () {
@@ -90,21 +86,15 @@ Future<void> _pumpSettingsView(
   tester.view.devicePixelRatio = 1.0;
   addTearDown(tester.view.resetPhysicalSize);
 
-  await tester.pumpWidget(
-    ProviderScope(
-      overrides: _settingsViewTestOverrides(),
-      child: MaterialApp(
-        locale: const Locale('zh'),
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        theme: buildAppTheme(Brightness.light),
-        home: Scaffold(
-          body: SizedBox(
-            width: viewportWidth,
-            height: 800,
-            child: const SettingsView(),
-          ),
-        ),
+  await pumpLocalizedApp(
+    tester,
+    wrapProviderScope: true,
+    overrides: settingsViewTestOverrides(),
+    home: Scaffold(
+      body: SizedBox(
+        width: viewportWidth,
+        height: 800,
+        child: const SettingsView(),
       ),
     ),
   );
@@ -118,23 +108,4 @@ void _expectMenuIcon(WidgetTester tester, Matcher matcher) {
     ),
     matcher,
   );
-}
-
-List<Override> _settingsViewTestOverrides() {
-  return <Override>[
-    settingsProvider.overrideWith(_FakeSettingsNotifier.new),
-    packageInfoProvider.overrideWith(
-      (Ref ref) async => PackageInfo(
-        appName: 'Hentai Library',
-        packageName: 'hentai_library',
-        version: '1.0.0',
-        buildNumber: '1',
-      ),
-    ),
-  ];
-}
-
-class _FakeSettingsNotifier extends SettingsNotifier {
-  @override
-  Future<AppSetting> build() async => AppSetting();
 }

--- a/app/test/ui/providers/comic_cover_providers_test.dart
+++ b/app/test/ui/providers/comic_cover_providers_test.dart
@@ -1,0 +1,136 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hentai_library/domain/models/entity/comic/comic.dart';
+import 'package:hentai_library/domain/models/enums.dart';
+import 'package:hentai_library/domain/repositories/comic_repository.dart';
+import 'package:hentai_library/domain/repositories/comic_thumbnail_repository.dart';
+import 'package:hentai_library/domain/thumbnail/thumbnail_event.dart';
+import 'package:hentai_library/ui/core/dto/comic_cover_state.dart';
+import 'package:hentai_library/ui/features/shell/di/repos.dart';
+import 'package:hentai_library/ui/providers/comic_cover_load_gate.dart';
+import 'package:hentai_library/ui/providers/comic_cover_providers.dart';
+import 'package:logging/logging.dart';
+import 'package:riverpod/misc.dart' show Override;
+import 'package:test/test.dart';
+
+void main() {
+  late _FakeComicRepo comicRepo;
+  late _FakeThumbnailRepo thumbnailRepo;
+  late ProviderContainer container;
+  late List<Completer<void>> gateBlockers;
+
+  setUp(() {
+    comicRepo = _FakeComicRepo();
+    thumbnailRepo = _FakeThumbnailRepo();
+    container = ProviderContainer(
+      overrides: <Override>[
+        comicRepoProvider.overrideWith((Ref ref) => comicRepo),
+        comicThumbnailRepoProvider.overrideWith((Ref ref) => thumbnailRepo),
+      ],
+    );
+    gateBlockers = <Completer<void>>[];
+  });
+
+  tearDown(() async {
+    for (final Completer<void> blocker in gateBlockers) {
+      if (!blocker.isCompleted) {
+        blocker.complete();
+      }
+    }
+    // Drain any queued gate work before the next test.
+    await Future<void>.delayed(Duration.zero);
+    container.dispose();
+  });
+
+  test(
+    'dispose while queued on load gate skips work and does not log SEVERE',
+    () async {
+      gateBlockers = List<Completer<void>>.generate(
+        ComicCoverLoadGate.maxConcurrent,
+        (_) => Completer<void>(),
+      );
+      for (final Completer<void> blocker in gateBlockers) {
+        unawaited(ComicCoverLoadGate.run(() => blocker.future));
+      }
+
+      final List<LogRecord> severeRecords = <LogRecord>[];
+      final StreamSubscription<LogRecord> logSub =
+          Logger('hentai.ui.comic_cover').onRecord.listen((LogRecord record) {
+            if (record.level >= Level.SEVERE) {
+              severeRecords.add(record);
+            }
+          });
+
+      final ProviderSubscription<ComicCoverState> coverSub = container.listen(
+        comicCoverProvider('comic-1'),
+        (_, _) {},
+      );
+      // build schedules ensureLoaded via microtask; let it queue behind the gate.
+      await Future<void>.delayed(Duration.zero);
+      expect(comicRepo.findByIdCalls, isEmpty);
+
+      coverSub.close();
+      await Future<void>.delayed(Duration.zero);
+
+      for (final Completer<void> blocker in gateBlockers) {
+        blocker.complete();
+      }
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(comicRepo.findByIdCalls, isEmpty);
+      expect(severeRecords, isEmpty);
+
+      await logSub.cancel();
+    },
+  );
+
+  test('loads NoCover when comic is missing', () async {
+    final ProviderSubscription<ComicCoverState> coverSub = container.listen(
+      comicCoverProvider('missing'),
+      (_, _) {},
+    );
+
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(
+      container.read(comicCoverProvider('missing')),
+      isA<ComicCoverNoCover>(),
+    );
+    expect(comicRepo.findByIdCalls, <String>['missing']);
+
+    coverSub.close();
+  });
+}
+
+class _FakeComicRepo implements ComicRepository {
+  final List<String> findByIdCalls = <String>[];
+
+  @override
+  Future<Comic?> findById(String comicId) async {
+    findByIdCalls.add(comicId);
+    return null;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeThumbnailRepo implements ComicThumbnailRepository {
+  @override
+  Future<ComicThumbnailRecord?> findByComicId(String comicId) async => null;
+
+  @override
+  Future<ComicThumbnailRecord?> ensureByComicId({
+    required String comicId,
+    required ThumbnailPriority priority,
+  }) async => null;
+
+  @override
+  Stream<ThumbnailEvent> watchEvents() => const Stream<ThumbnailEvent>.empty();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/core/crates/core/tests/comic_deletion.rs
+++ b/core/crates/core/tests/comic_deletion.rs
@@ -1,55 +1,13 @@
-use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+mod common;
+
+use std::path::Path;
 
 use hentai_core::{
     comic_id_from_path, create_local_library, create_remote_library, create_sync_handle,
     delete_comics_by_ids, find_comic_by_id, init_db_at_path, sync_library, SyncScanMode,
 };
-use sea_orm::{ConnectionTrait, Database, Statement};
+use sea_orm::{ConnectionTrait, Statement};
 use tempfile::TempDir;
-
-static DB_INIT_LOCK: Mutex<()> = Mutex::new(());
-
-fn with_global_db(test: impl FnOnce()) {
-    let _guard = DB_INIT_LOCK
-        .lock()
-        .expect("global db tests must run serially");
-    test();
-}
-
-fn fixture_sql() -> String {
-    std::fs::read_to_string(
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tests/fixtures/drift_v2.sql"),
-    )
-    .expect("read drift_v2.sql")
-}
-
-fn create_fixture_db(dir: &Path) -> PathBuf {
-    let db_path = dir.join("fixture.sqlite");
-    let runtime = tokio::runtime::Runtime::new().expect("runtime");
-    runtime.block_on(async {
-        let conn = Database::connect(format!(
-            "sqlite://{}?mode=rwc",
-            db_path.to_string_lossy().replace('\\', "/")
-        ))
-        .await
-        .expect("connect");
-        for stmt in fixture_sql().split(';') {
-            let sql = stmt.trim();
-            if sql.is_empty() || sql.starts_with("--") {
-                continue;
-            }
-            conn.execute(Statement::from_string(
-                sea_orm::DatabaseBackend::Sqlite,
-                sql.to_string(),
-            ))
-            .await
-            .expect("execute sql");
-        }
-    });
-    db_path
-}
-
 fn write_image_comic(dir: &Path) {
     std::fs::create_dir_all(dir).expect("mkdir comic");
     std::fs::write(dir.join("01.jpg"), b"fake-jpeg").expect("jpg");
@@ -94,9 +52,9 @@ async fn insert_remote_comic(comic_id: &str, path: &str, library_id: &str) {
 
 #[test]
 fn local_file_deletion_removes_disk_resource_and_db_row() {
-    with_global_db(|| {
+    common::with_global_db(|| {
         let temp = TempDir::new().expect("tempdir");
-        let db_path = create_fixture_db(temp.path());
+        let db_path = common::create_fixture_db(temp.path());
         let root = temp.path().join("lib");
         std::fs::create_dir_all(&root).expect("mkdir");
         let comic_path = root.join("vol1.cbz");
@@ -136,9 +94,9 @@ fn local_file_deletion_removes_disk_resource_and_db_row() {
 
 #[test]
 fn local_dir_deletion_removes_directory_resource() {
-    with_global_db(|| {
+    common::with_global_db(|| {
         let temp = TempDir::new().expect("tempdir");
-        let db_path = create_fixture_db(temp.path());
+        let db_path = common::create_fixture_db(temp.path());
         let root = temp.path().join("lib");
         std::fs::create_dir_all(&root).expect("mkdir");
         let comic_dir = root.join("folder_comic");
@@ -178,9 +136,9 @@ fn local_dir_deletion_removes_directory_resource() {
 
 #[test]
 fn missing_local_resource_still_allows_library_removal() {
-    with_global_db(|| {
+    common::with_global_db(|| {
         let temp = TempDir::new().expect("tempdir");
-        let db_path = create_fixture_db(temp.path());
+        let db_path = common::create_fixture_db(temp.path());
         let root = temp.path().join("lib");
         std::fs::create_dir_all(&root).expect("mkdir");
         let comic_path = root.join("vol1.cbz");
@@ -217,9 +175,9 @@ fn missing_local_resource_still_allows_library_removal() {
 
 #[test]
 fn rejects_local_resource_outside_library_root() {
-    with_global_db(|| {
+    common::with_global_db(|| {
         let temp = TempDir::new().expect("tempdir");
-        let db_path = create_fixture_db(temp.path());
+        let db_path = common::create_fixture_db(temp.path());
         let root = temp.path().join("lib");
         let outside = temp.path().join("outside.cbz");
         std::fs::create_dir_all(&root).expect("mkdir");
@@ -256,9 +214,9 @@ fn rejects_local_resource_outside_library_root() {
 
 #[test]
 fn remote_deletion_only_clears_library_row() {
-    with_global_db(|| {
+    common::with_global_db(|| {
         let temp = TempDir::new().expect("tempdir");
-        let db_path = create_fixture_db(temp.path());
+        let db_path = common::create_fixture_db(temp.path());
         let fake_remote_path = "https://example.com/library/vol1.cbz";
         let comic_id = comic_id_from_path(fake_remote_path);
 

--- a/core/crates/core/tests/comic_last_read_time.rs
+++ b/core/crates/core/tests/comic_last_read_time.rs
@@ -1,4 +1,5 @@
-use std::sync::Mutex;
+mod common;
+
 
 use hentai_core::{
     connection, find_comic_by_id, init_db_at_path, record_reading, ReadingHistoryDto,
@@ -6,14 +7,6 @@ use hentai_core::{
 use sea_orm::{ConnectionTrait, Statement};
 use tempfile::TempDir;
 
-static DB_INIT_LOCK: Mutex<()> = Mutex::new(());
-
-fn with_global_db(test: impl FnOnce()) {
-    let _guard = DB_INIT_LOCK
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    test();
-}
 
 fn seed_comic(comic_id: &str) {
     let runtime = tokio::runtime::Runtime::new().expect("runtime");
@@ -42,7 +35,7 @@ fn seed_comic(comic_id: &str) {
 
 #[test]
 fn find_comic_by_id_includes_last_read_time_when_history_exists() {
-    with_global_db(|| {
+    common::with_global_db(|| {
         let temp = TempDir::new().expect("tempdir");
         let db_path = temp.path().join("comic_last_read.sqlite");
         let runtime = tokio::runtime::Runtime::new().expect("runtime");

--- a/core/crates/core/tests/common/mod.rs
+++ b/core/crates/core/tests/common/mod.rs
@@ -1,0 +1,54 @@
+//! Shared DB fixture helpers for hentai-core integration tests.
+//!
+//! New integration tests must use these helpers instead of copying
+//! `DB_INIT_LOCK` / `create_fixture_db` boilerplate.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use sea_orm::{ConnectionTrait, Database, Statement};
+
+static DB_INIT_LOCK: Mutex<()> = Mutex::new(());
+
+/// Serializes tests that mutate the process-global DB connection.
+pub fn with_global_db(test: impl FnOnce()) {
+    let _guard = DB_INIT_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    test();
+}
+
+/// SQL fixture used by drift-v2 takeover / catalog integration tests.
+pub fn fixture_sql() -> String {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    fs::read_to_string(manifest_dir.join("../../tests/fixtures/drift_v2.sql"))
+        .expect("read drift_v2.sql")
+}
+
+/// Creates a SQLite file under [dir] seeded from [fixture_sql].
+pub fn create_fixture_db(dir: &Path) -> PathBuf {
+    let db_path = dir.join("fixture.sqlite");
+    let runtime = tokio::runtime::Runtime::new().expect("runtime");
+    runtime.block_on(async {
+        let conn = Database::connect(format!(
+            "sqlite://{}?mode=rwc",
+            db_path.to_string_lossy().replace('\\', "/")
+        ))
+        .await
+        .expect("connect");
+        for stmt in fixture_sql().split(';') {
+            let sql = stmt.trim();
+            if sql.is_empty() || sql.starts_with("--") {
+                continue;
+            }
+            conn.execute(Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                sql.to_string(),
+            ))
+            .await
+            .expect("execute sql");
+        }
+    });
+    db_path
+}

--- a/core/crates/core/tests/drop_series_reading_histories.rs
+++ b/core/crates/core/tests/drop_series_reading_histories.rs
@@ -1,57 +1,13 @@
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+mod common;
 
 use hentai_core::{connection, init_db_at_path};
-use sea_orm::{ConnectionTrait, Database, Statement};
+use sea_orm::{ConnectionTrait, Statement};
 use tempfile::TempDir;
-
-static DB_INIT_LOCK: Mutex<()> = Mutex::new(());
-
-fn with_global_db(test: impl FnOnce()) {
-    let _guard = DB_INIT_LOCK
-        .lock()
-        .expect("global db tests must run serially");
-    test();
-}
-
-fn fixture_sql() -> String {
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    fs::read_to_string(manifest_dir.join("../../tests/fixtures/drift_v2.sql"))
-        .expect("read drift_v2.sql")
-}
-
-fn create_fixture_db(dir: &Path) -> PathBuf {
-    let db_path = dir.join("fixture.sqlite");
-    let runtime = tokio::runtime::Runtime::new().expect("runtime");
-    runtime.block_on(async {
-        let conn = Database::connect(format!(
-            "sqlite://{}?mode=rwc",
-            db_path.to_string_lossy().replace('\\', "/")
-        ))
-        .await
-        .expect("connect");
-        for stmt in fixture_sql().split(';') {
-            let sql = stmt.trim();
-            if sql.is_empty() || sql.starts_with("--") {
-                continue;
-            }
-            conn.execute(Statement::from_string(
-                sea_orm::DatabaseBackend::Sqlite,
-                sql.to_string(),
-            ))
-            .await
-            .expect("execute sql");
-        }
-    });
-    db_path
-}
-
 #[test]
 fn migrated_db_has_no_series_reading_histories_table() {
-    with_global_db(|| {
+    common::with_global_db(|| {
         let temp = TempDir::new().expect("tempdir");
-        let db_path = create_fixture_db(temp.path());
+        let db_path = common::create_fixture_db(temp.path());
         let runtime = tokio::runtime::Runtime::new().expect("runtime");
         runtime.block_on(async {
             init_db_at_path(&db_path).await.expect("init_db");

--- a/core/crates/core/tests/named_facet.rs
+++ b/core/crates/core/tests/named_facet.rs
@@ -1,8 +1,6 @@
 //! Named metadata facet seam: junction replace + dict list + library-scoped distinct.
 
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+mod common;
 
 use hentai_core::{
     add_named_facet_name, connection, count_all_named_facet_names, count_named_facet_attachments,
@@ -10,50 +8,8 @@ use hentai_core::{
     list_all_named_facet_names, list_distinct_named_facet_names, list_named_facet_for_form,
     rename_named_facet_name, replace_comic_named_facet, JunctionNamedFacet,
 };
-use sea_orm::{ConnectionTrait, Database, Statement};
+use sea_orm::{ConnectionTrait, Statement};
 use tempfile::TempDir;
-
-static DB_INIT_LOCK: Mutex<()> = Mutex::new(());
-
-fn with_global_db(test: impl FnOnce()) {
-    let _guard = DB_INIT_LOCK
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    test();
-}
-
-fn fixture_sql() -> String {
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    fs::read_to_string(manifest_dir.join("../../tests/fixtures/drift_v2.sql"))
-        .expect("read drift_v2.sql")
-}
-
-fn create_fixture_db(dir: &Path) -> PathBuf {
-    let db_path = dir.join("fixture.sqlite");
-    let runtime = tokio::runtime::Runtime::new().expect("runtime");
-    runtime.block_on(async {
-        let conn = Database::connect(format!(
-            "sqlite://{}?mode=rwc",
-            db_path.to_string_lossy().replace('\\', "/")
-        ))
-        .await
-        .expect("connect");
-        for stmt in fixture_sql().split(';') {
-            let sql = stmt.trim();
-            if sql.is_empty() || sql.starts_with("--") {
-                continue;
-            }
-            conn.execute(Statement::from_string(
-                sea_orm::DatabaseBackend::Sqlite,
-                sql.to_string(),
-            ))
-            .await
-            .expect("execute sql");
-        }
-    });
-    db_path
-}
-
 async fn clear_facet_tables(db: &impl ConnectionTrait) {
     for table in [
         "comic_parodies",
@@ -119,11 +75,11 @@ async fn junction_names(
 
 #[test]
 fn replace_comic_named_facet_upserts_dict_and_replaces_junction() {
-    with_global_db(|| {
+    common::with_global_db(|| {
         let temp = TempDir::new().expect("tempdir");
         let root = temp.path().join("lib");
         std::fs::create_dir_all(&root).expect("mkdir");
-        let db_path = create_fixture_db(temp.path());
+        let db_path = common::create_fixture_db(temp.path());
         let runtime = tokio::runtime::Runtime::new().expect("runtime");
         runtime.block_on(async {
             init_db_at_path(&db_path).await.expect("init_db");
@@ -182,13 +138,13 @@ fn replace_comic_named_facet_upserts_dict_and_replaces_junction() {
 
 #[test]
 fn list_distinct_named_facet_names_scopes_to_library() {
-    with_global_db(|| {
+    common::with_global_db(|| {
         let temp = TempDir::new().expect("tempdir");
         let root_a = temp.path().join("lib_a");
         let root_b = temp.path().join("lib_b");
         std::fs::create_dir_all(&root_a).expect("mkdir a");
         std::fs::create_dir_all(&root_b).expect("mkdir b");
-        let db_path = create_fixture_db(temp.path());
+        let db_path = common::create_fixture_db(temp.path());
         let runtime = tokio::runtime::Runtime::new().expect("runtime");
         runtime.block_on(async {
             init_db_at_path(&db_path).await.expect("init_db");
@@ -241,11 +197,11 @@ fn list_distinct_named_facet_names_scopes_to_library() {
 
 #[test]
 fn list_named_facet_for_form_returns_attachment_counts_sorted_desc_then_name() {
-    with_global_db(|| {
+    common::with_global_db(|| {
         let temp = TempDir::new().expect("tempdir");
         let root = temp.path().join("lib");
         std::fs::create_dir_all(&root).expect("mkdir");
-        let db_path = create_fixture_db(temp.path());
+        let db_path = common::create_fixture_db(temp.path());
         let runtime = tokio::runtime::Runtime::new().expect("runtime");
         runtime.block_on(async {
             init_db_at_path(&db_path).await.expect("init_db");
@@ -323,11 +279,11 @@ fn list_named_facet_for_form_returns_attachment_counts_sorted_desc_then_name() {
 
 #[test]
 fn replace_comic_named_facet_works_for_all_junction_facets() {
-    with_global_db(|| {
+    common::with_global_db(|| {
         let temp = TempDir::new().expect("tempdir");
         let root = temp.path().join("lib");
         std::fs::create_dir_all(&root).expect("mkdir");
-        let db_path = create_fixture_db(temp.path());
+        let db_path = common::create_fixture_db(temp.path());
         let runtime = tokio::runtime::Runtime::new().expect("runtime");
         runtime.block_on(async {
             init_db_at_path(&db_path).await.expect("init_db");
@@ -363,11 +319,11 @@ fn replace_comic_named_facet_works_for_all_junction_facets() {
 
 #[test]
 fn generic_named_facet_dictionary_crud_and_paging_work_for_all_facets() {
-    with_global_db(|| {
+    common::with_global_db(|| {
         let temp = TempDir::new().expect("tempdir");
         let root = temp.path().join("lib");
         std::fs::create_dir_all(&root).expect("mkdir");
-        let db_path = create_fixture_db(temp.path());
+        let db_path = common::create_fixture_db(temp.path());
         let runtime = tokio::runtime::Runtime::new().expect("runtime");
         runtime.block_on(async {
             init_db_at_path(&db_path).await.expect("init_db");

--- a/core/crates/core/tests/reading_history_page.rs
+++ b/core/crates/core/tests/reading_history_page.rs
@@ -1,5 +1,6 @@
+mod common;
+
 use std::path::Path;
-use std::sync::Mutex;
 
 use hentai_core::{
     connection, fetch_reading_page, get_reading_by_comic_id, init_db_at_path, record_reading,
@@ -8,14 +9,6 @@ use hentai_core::{
 use sea_orm::{ConnectionTrait, Statement};
 use tempfile::TempDir;
 
-static DB_INIT_LOCK: Mutex<()> = Mutex::new(());
-
-fn with_global_db(test: impl FnOnce()) {
-    let _guard = DB_INIT_LOCK
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    test();
-}
 async fn create_reading_histories_table() {
     let db = connection().expect("connection");
     db.execute(Statement::from_string(
@@ -62,7 +55,7 @@ async fn seed_histories() {
 
 #[test]
 fn fetch_reading_page_returns_descending_pages() {
-    with_global_db(|| {
+    common::with_global_db(|| {
         let temp = TempDir::new().expect("tempdir");
         create_db(temp.path());
         let runtime = tokio::runtime::Runtime::new().expect("runtime");
@@ -95,7 +88,7 @@ fn fetch_reading_page_returns_descending_pages() {
 
 #[test]
 fn fetch_reading_page_filters_by_keyword_case_insensitively() {
-    with_global_db(|| {
+    common::with_global_db(|| {
         let temp = TempDir::new().expect("tempdir");
         create_db(temp.path());
         let runtime = tokio::runtime::Runtime::new().expect("runtime");
@@ -120,7 +113,7 @@ fn fetch_reading_page_filters_by_keyword_case_insensitively() {
 
 #[test]
 fn fetch_reading_page_treats_blank_keyword_as_unfiltered() {
-    with_global_db(|| {
+    common::with_global_db(|| {
         let temp = TempDir::new().expect("tempdir");
         create_db(temp.path());
         let runtime = tokio::runtime::Runtime::new().expect("runtime");
@@ -138,7 +131,7 @@ fn fetch_reading_page_treats_blank_keyword_as_unfiltered() {
 
 #[test]
 fn record_reading_decodes_html_entities_in_title() {
-    with_global_db(|| {
+    common::with_global_db(|| {
         let temp = TempDir::new().expect("tempdir");
         create_db(temp.path());
         let runtime = tokio::runtime::Runtime::new().expect("runtime");

--- a/core/crates/core/tests/series_comics_metadata.rs
+++ b/core/crates/core/tests/series_comics_metadata.rs
@@ -1,56 +1,11 @@
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+mod common;
 
 use hentai_core::{
     connection, fetch_series_comics_metadata, init_db_at_path, update_comic_user_meta,
     UpdateComicUserMetaDto,
 };
-use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
+use sea_orm::{ConnectionTrait, DatabaseConnection, Statement};
 use tempfile::TempDir;
-
-/// `init_db_at_path` 使用进程级全局连接，并行测试会互相覆盖。
-static DB_INIT_LOCK: Mutex<()> = Mutex::new(());
-
-fn with_global_db(test: impl FnOnce()) {
-    let _guard = DB_INIT_LOCK
-        .lock()
-        .expect("global db tests must run serially");
-    test();
-}
-
-fn fixture_sql() -> String {
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    fs::read_to_string(manifest_dir.join("../../tests/fixtures/drift_v2.sql"))
-        .expect("read drift_v2.sql")
-}
-
-fn create_fixture_db(dir: &Path) -> PathBuf {
-    let db_path = dir.join("fixture.sqlite");
-    let runtime = tokio::runtime::Runtime::new().expect("runtime");
-    runtime.block_on(async {
-        let conn = Database::connect(format!(
-            "sqlite://{}?mode=rwc",
-            db_path.to_string_lossy().replace('\\', "/")
-        ))
-        .await
-        .expect("connect");
-        for stmt in fixture_sql().split(';') {
-            let sql = stmt.trim();
-            if sql.is_empty() || sql.starts_with("--") {
-                continue;
-            }
-            conn.execute(Statement::from_string(
-                sea_orm::DatabaseBackend::Sqlite,
-                sql.to_string(),
-            ))
-            .await
-            .expect("execute sql");
-        }
-    });
-    db_path
-}
-
 async fn clear_library(db: &DatabaseConnection) {
     for table in [
         "series_items",
@@ -116,9 +71,9 @@ async fn seed_series_with_three_comics(db: &DatabaseConnection) {
 
 #[test]
 fn fetch_series_comics_metadata_aggregates_language_parody_character_first_seen_by_member_order() {
-    with_global_db(|| {
+    common::with_global_db(|| {
         let temp = TempDir::new().expect("tempdir");
-        let db_path = create_fixture_db(temp.path());
+        let db_path = common::create_fixture_db(temp.path());
         let runtime = tokio::runtime::Runtime::new().expect("runtime");
         runtime.block_on(async {
             init_db_at_path(&db_path).await.expect("init_db");
@@ -199,9 +154,9 @@ fn fetch_series_comics_metadata_aggregates_language_parody_character_first_seen_
 
 #[test]
 fn fetch_series_comics_metadata_omits_empty_language_parody_character() {
-    with_global_db(|| {
+    common::with_global_db(|| {
         let temp = TempDir::new().expect("tempdir");
-        let db_path = create_fixture_db(temp.path());
+        let db_path = common::create_fixture_db(temp.path());
         let runtime = tokio::runtime::Runtime::new().expect("runtime");
         runtime.block_on(async {
             init_db_at_path(&db_path).await.expect("init_db");

--- a/core/crates/core/tests/series_reading_context.rs
+++ b/core/crates/core/tests/series_reading_context.rs
@@ -1,55 +1,10 @@
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+mod common;
 
 use hentai_core::{
     connection, get_series_reading_context_by_comic_id, init_db_at_path,
 };
-use sea_orm::{ConnectionTrait, Database, DatabaseConnection, Statement};
+use sea_orm::{ConnectionTrait, DatabaseConnection, Statement};
 use tempfile::TempDir;
-
-/// `init_db_at_path` 使用进程级全局连接，并行测试会互相覆盖。
-static DB_INIT_LOCK: Mutex<()> = Mutex::new(());
-
-fn with_global_db(test: impl FnOnce()) {
-    let _guard = DB_INIT_LOCK
-        .lock()
-        .expect("global db tests must run serially");
-    test();
-}
-
-fn fixture_sql() -> String {
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    fs::read_to_string(manifest_dir.join("../../tests/fixtures/drift_v2.sql"))
-        .expect("read drift_v2.sql")
-}
-
-fn create_fixture_db(dir: &Path) -> PathBuf {
-    let db_path = dir.join("fixture.sqlite");
-    let runtime = tokio::runtime::Runtime::new().expect("runtime");
-    runtime.block_on(async {
-        let conn = Database::connect(format!(
-            "sqlite://{}?mode=rwc",
-            db_path.to_string_lossy().replace('\\', "/")
-        ))
-        .await
-        .expect("connect");
-        for stmt in fixture_sql().split(';') {
-            let sql = stmt.trim();
-            if sql.is_empty() || sql.starts_with("--") {
-                continue;
-            }
-            conn.execute(Statement::from_string(
-                sea_orm::DatabaseBackend::Sqlite,
-                sql.to_string(),
-            ))
-            .await
-            .expect("execute sql");
-        }
-    });
-    db_path
-}
-
 async fn clear_library(db: &DatabaseConnection) {
     for table in ["series_items", "series", "comic_meta", "comics"] {
         db.execute(Statement::from_string(
@@ -101,9 +56,9 @@ async fn seed_series_with_three_comics(db: &DatabaseConnection) {
 
 #[test]
 fn series_reading_context_for_member_comic_returns_ordered_ids_and_index() {
-    with_global_db(|| {
+    common::with_global_db(|| {
         let temp = TempDir::new().expect("tempdir");
-        let db_path = create_fixture_db(temp.path());
+        let db_path = common::create_fixture_db(temp.path());
         let runtime = tokio::runtime::Runtime::new().expect("runtime");
         runtime.block_on(async {
             init_db_at_path(&db_path).await.expect("init_db");
@@ -128,9 +83,9 @@ fn series_reading_context_for_member_comic_returns_ordered_ids_and_index() {
 
 #[test]
 fn series_reading_context_for_unassigned_comic_returns_none() {
-    with_global_db(|| {
+    common::with_global_db(|| {
         let temp = TempDir::new().expect("tempdir");
-        let db_path = create_fixture_db(temp.path());
+        let db_path = common::create_fixture_db(temp.path());
         let runtime = tokio::runtime::Runtime::new().expect("runtime");
         runtime.block_on(async {
             init_db_at_path(&db_path).await.expect("init_db");

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -1,0 +1,95 @@
+# Testing guide（CI vs 本地 · FRB 薄边 · UI 双轨）
+
+单一事实来源：PR 硬门禁保证什么、本地还应跑什么、Dart data 测什么、UI 快/慢轨如何晋升。对齐 ADR-0002（业务在 Rust `cargo test`；Dart 测 UI + FRB 薄边）。
+
+## CI hard gates（必须绿）
+
+| Job | 命令（可本地复现） | 失败含义 |
+|-----|-------------------|----------|
+| `test-rust` | `cargo test --manifest-path core/Cargo.toml` | Rust 核心（sync / reader / DB）回归 |
+| `analyze` · format | `cd app && dart format --output=none --set-exit-if-changed lib test` | 格式漂移 |
+| `analyze` · analyze | `cd app && flutter analyze` | 静态分析问题 |
+| `test-unit` | `cd app && flutter test test/domain test/core test/data test/project_layout_test.dart test/ui/core/widgets/actions/destructive_filled_button_test.dart test/ui/core/widgets/overlays/dialog/confirm` | domain / core / data 契约 / monorepo layout / 已晋升快轨 UI |
+
+新增 **data 契约测** 或 **已晋升的快轨 UI/纯逻辑测** 时：扩展 `test-unit` 的路径列表（或把文件放进已有 `test/data` / 已列入的快轨路径），不要另开「假绿」软门禁冒充硬跑。
+
+## Soft / 非阻塞
+
+| Job | 命令 | 说明 |
+|-----|------|------|
+| `test-widget (soft)` | `cd app && flutter test test/widget_test.dart` | Smoke only；`continue-on-error`。**绿 PR 不代表全量 UI 测已过。** |
+
+慢轨 viewport / shell / 大 widget（如 `test/ui/features/reader/*viewport*`、大面积 responsive shell）默认留在本地或 soft，除非按下方双轨规则显式晋升。
+
+## 本地全量
+
+合并前若你改了 UI 或怀疑 widget 回归，本地再跑：
+
+```bash
+cd app && flutter test
+cargo test --manifest-path core/Cargo.toml
+```
+
+CI **不会**跑全量 `test/ui`、不会跑 `integration_test`、不上 coverage 门禁。
+
+## ADR-0002 测试含义
+
+- **信任 `cargo test`**：Library sync / 阅读 I/O / DB / series 业务行为以 Rust 集成为准。
+- **Dart data**：只测 FRB ↔ domain 的 **mapper / error·call guard / adapter**（见 `app/test/data/`）。**不要**对真 FRB 或 `*_repository_impl` 写集成测（避免第二套集成栈）。
+- **Dart UI**：widget / 交互；优先薄 smoke + 抽纯逻辑到 unit。
+
+## UI 双轨（快硬 / 慢软）
+
+| 轨 | 进入条件 | CI |
+|----|----------|-----|
+| **快轨** | 低 timing、少 `pumpAndSettle`、无脆弱 viewport 尺寸依赖；优先纯逻辑 unit 或极薄 smoke | 可列入 `test-unit` 硬门禁 |
+| **慢轨** | 大壳、侧栏、多断点 responsive、阅读器 viewport 手势/时序 | soft 或仅本地；全量 `test/ui` **本波不硬门禁** |
+
+### 晋升快轨检查清单
+
+1. 测的是可观察契约，不绑私有结构。
+2. 本地连续跑稳定（无偶发 timeout）。
+3. 已改用共享 harness（见下），无新复制的 MaterialApp / `_Fake*` 样板。
+4. 在 PR 中显式列出路径，并改 `.github/workflows/ci.yml` 的 `test-unit` 命令。
+5. 评审确认后合入；失败必须挡合并。
+
+## 共享 harness（强制）
+
+新测 **必须**走共享入口，禁止再复制一套：
+
+| 侧 | 入口 | 用途 |
+|----|------|------|
+| Flutter | `app/test/support/`（如 `pump_localized_app.dart`、`fakes/`） | 本地化 pump、常用 overrides/fakes |
+| Rust | `core/crates/core/tests/common/` | DB init 锁、`create_fixture_db`、fixture SQL |
+
+迁移存量测试时顺手改到 harness；`test/features` 遗留路径被触及时迁到镜像的 `test/ui` / `test/data`，不要继续扩张 `test/features`。
+
+### Flutter 示例
+
+```dart
+await pumpLocalizedApp(
+  tester,
+  home: const Scaffold(body: MyWidget()),
+);
+```
+
+### Rust 示例
+
+```rust
+mod common;
+
+#[test]
+fn example() {
+    common::with_global_db(|| {
+        let temp = tempfile::TempDir::new().unwrap();
+        let db_path = common::create_fixture_db(temp.path());
+        // ...
+    });
+}
+```
+
+## Slice 2 inventory（#108）
+
+**新增契约测：** `series_frb_mapper`、`history_frb_mapper`、`reader_frb_mapper`、`thumbnail_frb_mapper`。
+
+**残留缺口（有意延后）：** `frb_zone_guard`；`comic_frb_mapper` 仍仅覆盖 sort/filter（缺 `mapRustComic` / page 映射等）；`mapPagedSeriesComicsResult`；真 FRB / `*_repository_impl`（本波不做）。


### PR DESCRIPTION
## Summary
- 落实 #106：CI 诚实硬门禁（含 analyze/format 与已有 data 单测）、FRB 薄层契约测补齐、Flutter/Rust 共享测试 harness，并新增 `docs/agents/testing.md`。
- 附带修复：封面 LoadGate dispose 竞态、阅读器首页→上一卷翻页不对称、更新检查对话框测试缺 `AppThemeTokens` 导致的虚假溢出。

## Test plan
- [ ] CI 全部硬门禁通过（Dart unit/analyze/format、Rust cargo test）
- [ ] 本地按需跑相关 UI 测确认 harness 迁移后仍绿
- [ ] 阅读器：首页翻页可进入上一卷；封面加载竞态不再抛 dispose Ref 错误


Made with [Cursor](https://cursor.com)